### PR TITLE
chore: rename project from wordgum to wordbeetle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "wordgum-frontend",
+  "name": "wordbeetle-frontend",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "wordgum-frontend",
+      "name": "wordbeetle-frontend",
       "version": "0.1.0",
       "dependencies": {
         "next": "16.0.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "wordgum-frontend",
+  "name": "wordbeetle-frontend",
   "version": "0.1.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary
This PR renames the project from `wordgum-frontend` to `wordbeetle-frontend`.

## Changes
- Updated project name in `package.json`
- Updated project name in `package-lock.json`