### PR TITLE
remove AvatarFallback from UserMenu

### DIFF
--- a/src/shared/components/layout/server/Header/UserMenu/UserMenuPresenter.tsx
+++ b/src/shared/components/layout/server/Header/UserMenu/UserMenuPresenter.tsx
@@ -1,9 +1,5 @@
 import { signOutAction } from '@/features/auth/actions/sign-out.action';
-import {
-  Avatar,
-  AvatarFallback,
-  AvatarImage,
-} from '@/shared/components/ui/avatar';
+import { Avatar, AvatarImage } from '@/shared/components/ui/avatar';
 import { Button } from '@/shared/components/ui/button';
 import {
   DropdownMenu,
@@ -46,7 +42,6 @@ export async function UserMenuPresenter({
               src={image ?? '/placeholder.svg'}
               alt={name ?? 'User'}
             />
-            <AvatarFallback>{name?.[0] ?? 'U'}</AvatarFallback>
           </Avatar>
         </button>
       </DropdownMenuTrigger>


### PR DESCRIPTION
## Description

This PR removes the `AvatarFallback` component from the `UserMenuPresenter` component as it is redundant with the existing Suspense fallback in the parent Header component.

## Motivation

The `Header` component already implements a Suspense fallback that displays a loading skeleton while the `UserMenu` is loading:

```tsx
<Suspense
  fallback={
    <div className="w-10 h-10 rounded-full bg-muted/50 border-2 border-border animate-pulse" />
  }
>
  <UserMenu />
</Suspense>
```

This means the `AvatarFallback` component inside `UserMenuPresenter` is unnecessary, as the Suspense boundary handles the loading state before the component renders. Removing it simplifies the component and eliminates redundant fallback logic.