### PR TITLE
chore: add Claude Code project configuration

### DIFF
--- a/.claude/commands/commit-push-pr.md
+++ b/.claude/commands/commit-push-pr.md
@@ -1,0 +1,81 @@
+---
+allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git stash:*), Bash(git pull:*), Bash(git fetch:*), Bash(git diff:*), Bash(git log:*), Bash(cat tmp/pr_body.md), Bash(rm tmp/pr_body.md), AskUserQuestion
+description: Commit, push, and open a PR
+---
+
+## Context
+
+- Current git status: !`git status`
+- Current git diff (uncommitted changes): !`git diff HEAD`
+- Current branch: !`git branch --show-current`
+- Existing commits on this branch (since main): !`git log origin/main..HEAD --oneline`
+- Full diff from main (committed + uncommitted): !`git diff origin/main...HEAD`
+
+## Prohibited actions
+
+- Do NOT rename branches (`git branch -m`). Always create a new branch instead.
+
+## Your task
+
+Based on the above context:
+
+### Pre-check
+
+- If there are no uncommitted changes AND no commits ahead of main, inform the user and stop. Do NOT proceed.
+
+### 1. Analyze changes and propose commit groups
+
+Examine the diff and group changes into logical commits:
+
+- Group files that serve the same purpose
+- Each group needs: a list of files and a short commit message in English
+- Order groups by dependency
+- If there is only one file changed or all changes are clearly related, propose a single group
+
+Present your proposed groupings to the user as a numbered list showing files and commit message per group. Then use AskUserQuestion to confirm:
+
+- "Proceed as proposed"
+- "Combine into one commit"
+- "Let me regroup" (user describes preferred grouping via Other)
+
+If the user selects "Let me regroup", revise the groupings based on their input and re-confirm.
+
+### 2. Branch handling
+
+Derive a branch name from the overall set of changes. The name must follow: `feature/<topic>`, `fix/<topic>`, `refactor/<topic>`, `docs/<topic>`, or `chore/<topic>`.
+
+**Always** confirm the branch name with the user using AskUserQuestion:
+
+- Show your proposed branch name
+- "Use this name"
+- "Suggest alternatives" (you propose 2-3 alternatives, then re-confirm)
+- The user can also type a custom name via Other
+
+**If on main:**
+
+- Stash uncommitted changes if any (`git stash`), skip if working tree is clean
+- Fetch and pull the latest main (`git fetch origin && git pull origin main`)
+- Create and switch to the confirmed branch (`git checkout -b <branch-name>`)
+- Pop the stash if it was used (`git stash pop`)
+
+**If on a non-main branch:**
+
+- If the confirmed name matches the current branch, stay on it
+- Otherwise: stash changes → `git checkout main` → fetch/pull latest → `git checkout -b <new-branch>` → pop stash
+
+### 3. Commit and push
+
+For each commit group (in the confirmed order):
+
+- Stage only the files in that group with `git add`
+- Create a commit with the group's message
+- Do NOT include `Co-Authored-By` or any AI attribution in commit messages
+
+After all commits are created, push the branch: `git push -u origin <branch-name>`
+
+### 4. Create pull request
+
+- Write PR body to `tmp/pr_body.md` summarizing all commits (both existing and newly created)
+- Create a pull request: `gh pr create -t "<title>" -F tmp/pr_body.md`
+- Title and body must be in English
+- Clean up: `rm tmp/pr_body.md`

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,0 +1,66 @@
+---
+allowed-tools: Bash(git checkout:*), Bash(git add:*), Bash(git status:*), Bash(git commit:*), Bash(git stash:*), Bash(git pull:*), Bash(git fetch:*), Bash(git diff:*), AskUserQuestion
+description: Analyze changes and create well-organized commits
+---
+
+## Context
+
+- Current git status: !`git status`
+- Current git diff (uncommitted changes): !`git diff HEAD`
+- Current branch: !`git branch --show-current`
+
+## Your task
+
+Based on the above context:
+
+### Pre-check
+
+- If there are no uncommitted changes, inform the user and stop. Do NOT proceed.
+
+### 1. Analyze changes and propose commit groups
+
+Examine the diff and group changes into logical commits:
+
+- Group files that serve the same purpose
+- Each group needs: a list of files and a short commit message in English
+- Order groups by dependency
+- If there is only one file changed or all changes are clearly related, propose a single group
+
+Present your proposed groupings to the user as a numbered list showing files and commit message per group. Then use AskUserQuestion to confirm:
+
+- "Proceed as proposed"
+- "Combine into one commit"
+- "Let me regroup" (user describes preferred grouping via Other)
+
+If the user selects "Let me regroup", revise the groupings based on their input and re-confirm.
+
+### 2. Branch handling
+
+Derive a branch name from the overall set of changes. The name must follow: `feature/<topic>`, `fix/<topic>`, `refactor/<topic>`, `docs/<topic>`, or `chore/<topic>`.
+
+**Always** confirm the branch name with the user using AskUserQuestion:
+
+- Show your proposed branch name
+- "Use this name"
+- "Suggest alternatives" (you propose 2-3 alternatives, then re-confirm)
+- The user can also type a custom name via Other
+
+**If on main:**
+
+- Stash uncommitted changes if any (`git stash`), skip if working tree is clean
+- Fetch and pull the latest main (`git fetch origin && git pull origin main`)
+- Create and switch to the confirmed branch (`git checkout -b <branch-name>`)
+- Pop the stash if it was used (`git stash pop`)
+
+**If on a non-main branch:**
+
+- If the confirmed name matches the current branch, stay on it
+- Otherwise: stash changes → `git checkout main` → fetch/pull latest → `git checkout -b <new-branch>` → pop stash
+
+### 3. Commit
+
+For each commit group (in the confirmed order):
+
+- Stage only the files in that group with `git add`
+- Create a commit with the group's message
+- Do NOT include `Co-Authored-By` or any AI attribution in commit messages

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,73 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+WordBeetle Frontend — a Next.js 16 (App Router) application with React 19, TypeScript, and a Rails API backend. Authentication via NextAuth.js v5 (Google/GitHub OAuth). The backend runs at `API_URL` (default `http://localhost:3001/api/v1`).
+
+## Commands
+
+- `pnpm install` — install dependencies (pnpm is enforced via preinstall script)
+- `pnpm dev` — start dev server (http://localhost:3000)
+- `pnpm build` — production build
+- `pnpm lint` — run ESLint
+
+No test framework is configured yet.
+
+## Architecture
+
+```
+src/
+├── app/                    # Next.js App Router (routes, layouts, global CSS)
+├── features/               # Feature modules (domain-specific code)
+│   └── auth/               # Auth feature
+│       ├── actions/        # Server Actions (sign-in.action.ts, sign-out.action.ts)
+│       ├── components/server/  # Server components (AuthForm, AuthPageTemplate, ProviderIcon)
+│       ├── lib/            # Auth config (auth.ts, providers.ts)
+│       └── types/          # Type extensions (next-auth.d.ts)
+├── shared/                 # Cross-feature reusable code
+│   ├── components/
+│   │   ├── layout/server/  # Layout components (Header, UserMenu)
+│   │   └── ui/             # shadcn/ui primitives
+│   └── lib/                # Utilities (cn helper)
+└── middleware.ts            # Auth guard (redirects authenticated users from /auth)
+```
+
+### Key patterns
+
+- **Feature-based organization**: Domain logic lives in `src/features/{feature}/` with actions, components, lib, and types subdirectories.
+- **Shared code** goes in `src/shared/` — UI primitives, layout components, utilities.
+- **Container/Presenter**: Server components split into Container (data fetching) and Presenter (rendering with `'use cache'`). See `UserMenuContainer`/`UserMenuPresenter`.
+- **Server Components by default**. Only use `'use client'` when interactivity is required.
+- **Server Actions** for mutations, suffixed `.action.ts`.
+- **shadcn/ui** (new-york style, Radix UI + Tailwind CSS + CVA). Components live in `src/shared/components/ui/`.
+
+### Auth flow
+
+1. OAuth via NextAuth.js (Google/GitHub) → JWT callback stores `idToken`
+2. On sign-in, `idToken` is verified against Rails API (`POST {API_URL}/auth/google`)
+3. Session callback exposes `idToken` for downstream API requests
+
+## Code Style & Lint Rules
+
+**ESLint** (flat config, `eslint.config.mjs`):
+- `@typescript-eslint/strict-boolean-expressions` — no truthy/falsy coercion; use explicit comparisons (e.g., `!== undefined`, `!== null`)
+- `@typescript-eslint/switch-exhaustiveness-check` — no default case for exhaustive switches
+- `no-implicit-coercion` — no `!!`, `+""`, etc.
+- `prefer-template` — use template literals over string concatenation
+- `import/no-cycle` — no circular dependencies
+- `unicorn/prefer-switch` — prefer switch over if-else chains
+
+**Prettier** (`.prettierrc`): single quotes, 80 char width, ES5 trailing commas, `prettier-plugin-organize-imports`.
+
+## Environment Variables
+
+Required in `.env.local`:
+- `AUTH_SECRET` — NextAuth secret
+- `AUTH_GOOGLE_ID` / `AUTH_GOOGLE_SECRET` — Google OAuth credentials
+- `API_URL` — Rails backend base URL
+
+## Path Aliases
+
+`@/*` maps to `./src/*` (configured in `tsconfig.json`).


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` with project overview, architecture, code style rules, and development commands for Claude Code
- Add custom slash commands (`.claude/commands/`) for commit and commit-push-pr workflows

## Changes

- `CLAUDE.md` — Project instructions for Claude Code (architecture, lint rules, auth flow, environment variables)
- `.claude/commands/commit.md` — Custom slash command for structured commits
- `.claude/commands/commit-push-pr.md` — Custom slash command for commit, push, and PR creation
