### PR TITLE
chore: add MCP config for next-devtools integration

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "next-devtools": {
+      "command": "npx",
+      "args": ["-y", "next-devtools-mcp@latest"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `.mcp.json` configuration file for `next-devtools` MCP server integration
- Enables Claude Code and other MCP clients to use the next-devtools tooling with this project

## Changes

- **`.mcp.json`**: New MCP server config that runs `next-devtools-mcp@latest` via `npx`
