### PR TITLE
Remove user_id from API requests and auth flow

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -24,7 +24,12 @@ paths:
                 type: object
                 properties:
                   user:
-                    $ref: "#/components/schemas/User"
+                    type: object
+                    properties:
+                      guest_expires_at:
+                        type: string
+                        format: date-time
+                        description: Expiration time for the guest user (7 days after creation)
                   token:
                     type: string
                     description: Signed guest token for subsequent requests
@@ -47,7 +52,16 @@ paths:
                 type: object
                 properties:
                   user:
-                    $ref: "#/components/schemas/User"
+                    type: object
+                    properties:
+                      email:
+                        type: string
+                      name:
+                        type: string
+                        nullable: true
+                      avatar_url:
+                        type: string
+                        nullable: true
         "400":
           description: Authorization header missing
           content:
@@ -94,10 +108,8 @@ paths:
               properties:
                 wordbook:
                   type: object
-                  required: [user_id, title]
+                  required: [title]
                   properties:
-                    user_id:
-                      type: integer
                     title:
                       type: string
       responses:
@@ -141,8 +153,6 @@ paths:
                 wordbook:
                   type: object
                   properties:
-                    user_id:
-                      type: integer
                     title:
                       type: string
       responses:
@@ -514,10 +524,8 @@ paths:
               properties:
                 setting:
                   type: object
-                  required: [user_id, hard_interval, uncertain_interval, easy_interval]
+                  required: [hard_interval, uncertain_interval, easy_interval]
                   properties:
-                    user_id:
-                      type: integer
                     hard_interval:
                       $ref: "#/components/schemas/IntervalInput"
                     uncertain_interval:
@@ -565,8 +573,6 @@ paths:
                 setting:
                   type: object
                   properties:
-                    user_id:
-                      type: integer
                     hard_interval:
                       $ref: "#/components/schemas/IntervalInput"
                     uncertain_interval:

--- a/src/app/(authenticated)/wordbooks/[wordbookId]/edit/page.tsx
+++ b/src/app/(authenticated)/wordbooks/[wordbookId]/edit/page.tsx
@@ -2,9 +2,8 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { WordbookForm } from '@/components/wordbook/wordbook-form';
 import { getWordbook } from '@/lib/api/wordbooks';
-import { auth } from '@/lib/auth';
 import type { Metadata } from 'next';
-import { notFound, redirect } from 'next/navigation';
+import { notFound } from 'next/navigation';
 import { Suspense } from 'react';
 
 export const metadata: Metadata = {
@@ -20,13 +19,6 @@ async function EditWordbookContent({
 }: {
   wordbookId: string;
 }) {
-  const session = await auth();
-  const userId = session?.user?.apiUserId;
-
-  if (userId === undefined) {
-    redirect('/auth');
-  }
-
   let wordbook;
   try {
     wordbook = await getWordbook(Number(wordbookId));
@@ -40,7 +32,7 @@ async function EditWordbookContent({
         <CardTitle>単語帳を編集</CardTitle>
       </CardHeader>
       <CardContent>
-        <WordbookForm wordbook={wordbook} userId={userId} />
+        <WordbookForm wordbook={wordbook} />
       </CardContent>
     </Card>
   );

--- a/src/app/(authenticated)/wordbooks/new/page.tsx
+++ b/src/app/(authenticated)/wordbooks/new/page.tsx
@@ -1,30 +1,21 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { WordbookForm } from '@/components/wordbook/wordbook-form';
-import { auth } from '@/lib/auth';
 import type { Metadata } from 'next';
-import { redirect } from 'next/navigation';
 import { Suspense } from 'react';
 
 export const metadata: Metadata = {
   title: '新しい単語帳 | WordBeetle',
 };
 
-async function NewWordbookContent() {
-  const session = await auth();
-  const userId = session?.user?.apiUserId;
-
-  if (userId === undefined) {
-    redirect('/auth');
-  }
-
+function NewWordbookContent() {
   return (
     <Card>
       <CardHeader>
         <CardTitle>新しい単語帳を作成</CardTitle>
       </CardHeader>
       <CardContent>
-        <WordbookForm userId={userId} />
+        <WordbookForm />
       </CardContent>
     </Card>
   );

--- a/src/components/wordbook/wordbook-form.tsx
+++ b/src/components/wordbook/wordbook-form.tsx
@@ -15,10 +15,9 @@ import { useActionState } from 'react';
 
 type WordbookFormProps = {
   wordbook?: Wordbook;
-  userId: number;
 };
 
-export function WordbookForm({ wordbook, userId }: WordbookFormProps) {
+export function WordbookForm({ wordbook }: WordbookFormProps) {
   const isEditing = wordbook !== undefined;
   const action = isEditing ? updateWordbookAction : createWordbookAction;
   const [state, formAction, isPending] = useActionState<
@@ -31,7 +30,6 @@ export function WordbookForm({ wordbook, userId }: WordbookFormProps) {
       {isEditing && (
         <input type="hidden" name="wordbookId" value={wordbook.id} />
       )}
-      <input type="hidden" name="userId" value={userId} />
 
       <div className="space-y-2">
         <Label htmlFor="title">タイトル</Label>

--- a/src/data/guest-user.ts
+++ b/src/data/guest-user.ts
@@ -4,13 +4,7 @@ import type { GuestUserDTO } from '@/types/dto';
 
 type GuestAuthResponse = {
   user: {
-    id: number;
-    provider: string;
-    provider_uid: string;
-    name: string | null;
-    email: string | null;
-    avatar_url: string | null;
-    guest_expires_at: string | null;
+    guest_expires_at: string;
   };
   token: string;
 };
@@ -31,9 +25,7 @@ export async function createGuestUser(): Promise<GuestUserDTO> {
   const result = (await response.json()) as GuestAuthResponse;
 
   return {
-    id: String(result.user.id),
-    name: result.user.name ?? 'ゲスト',
+    name: 'ゲスト',
     token: result.token,
-    apiUserId: result.user.id,
   };
 }

--- a/src/lib/actions/settings-actions.ts
+++ b/src/lib/actions/settings-actions.ts
@@ -2,7 +2,6 @@
 
 import { ApiError } from '@/lib/api/client';
 import { createSetting, listSettings, updateSetting } from '@/lib/api/settings';
-import { auth } from '@/lib/auth';
 import type { Interval } from '@/types/api';
 import { revalidatePath } from 'next/cache';
 
@@ -22,13 +21,6 @@ export async function saveSettingsAction(
   _prevState: SettingsActionState,
   formData: FormData,
 ): Promise<SettingsActionState> {
-  const session = await auth();
-  const userId = session?.user?.apiUserId;
-
-  if (userId === undefined) {
-    return { errors: ['認証情報が取得できません'] };
-  }
-
   const hardInterval = parseInterval(formData, 'hard');
   const uncertainInterval = parseInterval(formData, 'uncertain');
   const easyInterval = parseInterval(formData, 'easy');
@@ -45,7 +37,6 @@ export async function saveSettingsAction(
       });
     } else {
       await createSetting({
-        user_id: userId,
         hard_interval: hardInterval,
         uncertain_interval: uncertainInterval,
         easy_interval: easyInterval,

--- a/src/lib/actions/wordbook-actions.ts
+++ b/src/lib/actions/wordbook-actions.ts
@@ -23,15 +23,8 @@ export async function createWordbookAction(
     return { errors: ['タイトルを入力してください'] };
   }
 
-  const userId = formData.get('userId');
-
-  if (typeof userId !== 'string') {
-    return { errors: ['ユーザー情報が取得できません'] };
-  }
-
   try {
     const wordbook = await createWordbook({
-      user_id: Number(userId),
       title: title.trim(),
     });
     revalidatePath('/dashboard');

--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -14,12 +14,8 @@ const guestProvider = Credentials({
     const guest = await createGuestUser();
 
     return {
-      id: guest.id,
       name: guest.name,
-      email: null,
-      image: null,
       idToken: guest.token,
-      apiUserId: guest.apiUserId,
     };
   },
 });
@@ -37,10 +33,8 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       if (trigger === 'signIn' && account?.provider === 'guest') {
         const guestUser = user as {
           idToken?: string;
-          apiUserId?: number;
         };
         token.idToken = guestUser.idToken;
-        token.apiUserId = guestUser.apiUserId;
         return token;
       }
 
@@ -75,14 +69,6 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
             );
             throw new Error(`Authentication failed: ${response.status}`);
           }
-
-          const data = (await response.json()) as {
-            user?: { id?: number };
-          };
-
-          if (data.user?.id !== undefined) {
-            token.apiUserId = data.user.id;
-          }
         } catch (error) {
           console.error('API connection error:', error);
           throw error;
@@ -93,7 +79,6 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     },
     session({ session, token }) {
       session.user.idToken = token.idToken;
-      session.user.apiUserId = token.apiUserId;
 
       return session;
     },

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -66,7 +66,6 @@ export type Setting = {
 };
 
 export type CreateWordbookInput = {
-  user_id: number;
   title: string;
 };
 
@@ -112,7 +111,6 @@ export type UpdateExampleInput = {
 };
 
 export type CreateSettingInput = {
-  user_id: number;
   hard_interval: Interval;
   uncertain_interval: Interval;
   easy_interval: Interval;

--- a/src/types/dto.ts
+++ b/src/types/dto.ts
@@ -1,6 +1,4 @@
 export type GuestUserDTO = {
-  id: string;
   name: string;
   token: string;
-  apiUserId: number;
 };

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -4,7 +4,6 @@ import 'next-auth/jwt';
 declare module 'next-auth/jwt' {
   interface JWT {
     idToken?: string;
-    apiUserId?: number;
   }
 }
 
@@ -12,7 +11,6 @@ declare module 'next-auth' {
   interface Session {
     user: {
       idToken?: string;
-      apiUserId?: number;
     } & DefaultSession['user'];
   }
 }


### PR DESCRIPTION
## Summary

- Remove `apiUserId` from NextAuth JWT, session, guest DTO, and auth config — the backend now identifies users from the auth token
- Remove `user_id` from `CreateWordbookInput` and `CreateSettingInput` API types and corresponding server actions
- Remove `userId` prop from `WordbookForm` and its parent pages (`new` and `edit`)
- Update OpenAPI spec to reflect the removed `user_id` fields and updated auth response schemas
