### PR TITLE
fix: store Rails API JWT instead of Google ID token as session accessToken

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,10 +68,9 @@ src/
 
 ### Auth flow
 
-1. **OAuth**: Google/GitHub via NextAuth.js → JWT callback stores `idToken` + `apiUserId`
-2. On sign-in, `idToken` is verified against Rails API (`POST {API_URL}/auth/google`)
-3. **Guest**: NextAuth Credentials provider → `POST {API_URL}/auth/guest` → token stored in JWT like OAuth
-4. Session callback exposes `idToken` and `apiUserId` for downstream API requests
+1. **OAuth**: Google via NextAuth.js → JWT callback sends Google ID token to Rails API (`POST {API_URL}/auth/google`) → stores Rails JWT as `accessToken`
+2. **Guest**: NextAuth Credentials provider → `POST {API_URL}/auth/guest` → Rails JWT stored as `accessToken` in JWT
+3. Session callback exposes `accessToken` for downstream API requests
 
 ### SRS (Spaced Repetition)
 

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -12,7 +12,7 @@ export class ApiError extends Error {
 
 async function getToken(): Promise<string> {
   const session = await auth();
-  const token = session?.user?.idToken;
+  const token = session?.user?.accessToken;
 
   if (token === undefined || token === null) {
     throw new Error('Not authenticated');

--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -15,7 +15,7 @@ const guestProvider = Credentials({
 
     return {
       name: guest.name,
-      idToken: guest.token,
+      accessToken: guest.token,
     };
   },
 });
@@ -32,21 +32,19 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     async jwt({ token, account, trigger, user }) {
       if (trigger === 'signIn' && account?.provider === 'guest') {
         const guestUser = user as {
-          idToken?: string;
+          accessToken?: string;
         };
-        token.idToken = guestUser.idToken;
+        token.accessToken = guestUser.accessToken;
         return token;
       }
 
-      const idToken = account?.id_token;
+      if (trigger === 'signIn' && account?.provider === 'google') {
+        const googleIdToken = account.id_token;
 
-      if (idToken === undefined) {
-        return token;
-      }
+        if (googleIdToken === undefined) {
+          throw new Error('Google ID token is missing');
+        }
 
-      token.idToken = idToken;
-
-      if (trigger === 'signIn') {
         const apiUrl = process.env.API_URL;
 
         if (apiUrl === undefined) {
@@ -57,7 +55,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           const response = await fetch(`${apiUrl}/auth/google`, {
             method: 'POST',
             headers: {
-              Authorization: `Bearer ${idToken}`,
+              Authorization: `Bearer ${googleIdToken}`,
             },
           });
 
@@ -69,6 +67,11 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
             );
             throw new Error(`Authentication failed: ${response.status}`);
           }
+
+          const result = (await response.json()) as {
+            token: string;
+          };
+          token.accessToken = result.token;
         } catch (error) {
           console.error('API connection error:', error);
           throw error;
@@ -78,7 +81,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       return token;
     },
     session({ session, token }) {
-      session.user.idToken = token.idToken;
+      session.user.accessToken = token.accessToken;
 
       return session;
     },

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -3,14 +3,14 @@ import 'next-auth/jwt';
 
 declare module 'next-auth/jwt' {
   interface JWT {
-    idToken?: string;
+    accessToken?: string;
   }
 }
 
 declare module 'next-auth' {
   interface Session {
     user: {
-      idToken?: string;
+      accessToken?: string;
     } & DefaultSession['user'];
   }
 }


### PR DESCRIPTION
## Summary

- **Fix OAuth token flow**: Previously, the Google OAuth ID token was stored in the session and used for Rails API requests, causing authentication failures. Now the Google ID token is only used to call `POST /auth/google`, and the Rails-issued JWT from the response is stored as `accessToken`.
- **Rename `idToken` → `accessToken`**: Updated types (`next-auth.d.ts`), auth config (`lib/auth/index.ts`), API client (`lib/api/client.ts`), and docs (`CLAUDE.md`) to reflect that the stored token is a Rails API access token, not a Google ID token.
- **Guest login unaffected**: Guest flow already stored the Rails JWT correctly; only the field name changed.

## Details

The root cause was that `response.json()` was never called after `POST /auth/google`, so the Rails JWT in the response body was discarded. The Google ID token was then sent as `Authorization: Bearer` on subsequent API calls, which Rails rejected.

### Changes
- `src/types/next-auth.d.ts` — `idToken` → `accessToken` in JWT and Session type augmentations
- `src/lib/auth/index.ts` — Parse Rails API response, store `result.token` as `accessToken`; explicit `account?.provider === 'google'` check; remove fallthrough that stored `account.id_token` directly
- `src/lib/api/client.ts` — Read `session.user.accessToken` instead of `idToken`
- `CLAUDE.md` — Update auth flow documentation

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm build` succeeds
- [x] Guest login → dashboard shows wordbook list
- [x] Google login → dashboard shows wordbook list
- [x] Logout → redirected to /auth
