### PR TITLE
feat: add guest-to-Google account migration

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,88 @@
+# 認証・認可
+
+## 認証フロー概要
+
+```
+[クライアント] --Google ID Token--> POST /api/v1/auth/google --> [JWT発行]
+[クライアント] ----------------------> POST /api/v1/auth/guest  --> [JWT発行]
+[クライアント] --Bearer JWT---------> GET /api/v1/wordbooks    --> [リソース返却]
+```
+
+1. **Google認証**: クライアントがGoogle ID tokenを`Authorization: Bearer <id_token>`で送信。サーバーがトークンを検証し、ユーザーを検索または作成してJWTを返却。
+2. **ゲスト認証**: クライアントがPOSTリクエストを送信。サーバーがゲストユーザーを作成してJWTを返却。
+3. **APIアクセス**: 以降のリクエストでは`Authorization: Bearer <jwt>`ヘッダーでJWTを送信。
+
+## JWTの構造
+
+アルゴリズム: HS256（HMAC-SHA256）
+
+### ペイロード（クレーム）
+
+| クレーム | 説明 |
+|---------|------|
+| `sub` | ユーザーID（`users.id`） |
+| `exp` | 有効期限（Unix timestamp） |
+| `iat` | 発行日時（Unix timestamp） |
+
+### 署名鍵
+
+`Rails.application.secret_key_base`を使用。
+
+## 有効期限
+
+| 認証方法 | 有効期限 |
+|---------|---------|
+| Google認証 | 30日（発行時点から） |
+| ゲスト認証 | 7日（`guest_expires_at`と一致） |
+
+ゲスト認証のJWT有効期限は、ユーザーレコードの`guest_expires_at`と同一の値を使用。これによりDBとトークンの有効期限が一致することを保証。
+
+## ゲストユーザーデータの引き継ぎ（移行）
+
+ゲストユーザーが Google 認証で本登録する際、`POST /api/v1/auth/google` に `guest_token` パラメータを付与することでデータを引き継ぐ。
+
+```
+[クライアント] --Bearer Google ID Token + body { guest_token: JWT }--> POST /api/v1/auth/google --> [移行 + JWT発行]
+```
+
+### フロー
+
+1. クライアントが Google ID token を `Authorization: Bearer <id_token>` で送信（通常と同じ）
+2. リクエストボディに `{ "guest_token": "<guest_jwt>" }` を含める
+3. サーバーが Google ID token を検証し、guest_token から対象ゲストユーザーを特定
+4. 移行処理を実行し、新しい JWT を返却
+
+### 2つのシナリオ
+
+| シナリオ | 条件 | 処理 |
+|---------|------|------|
+| インプレース変換 | Google アカウントが未登録 | ゲストユーザーレコードを Google ユーザーに変換。全データがそのまま保持される |
+| マージ | Google アカウントが既に存在 | ゲストの単語帳を既存 Google ユーザーに移行。ゲストユーザーは削除 |
+
+### エラーレスポンス（移行固有）
+
+| ステータス | 条件 | レスポンス |
+|-----------|------|-----------|
+| 401 Unauthorized | 無効な guest_token / ゲストユーザーが見つからない | `{ "error": "Invalid guest token" }` |
+| 422 Unprocessable Entity | guest_token のユーザーがゲストでない | `{ "error": "User is not a guest" }` |
+
+## 認可（リソーススコーピング）
+
+全リソースエンドポイントは`current_user`を起点にスコーピング:
+
+| リソース | スコーピング方法 |
+|---------|----------------|
+| Wordbooks | `current_user.wordbooks` |
+| Words | `Word.joins(:wordbook).where(wordbooks: { user_id: current_user.id })` |
+| Meanings | `Meaning.joins(word: :wordbook).where(wordbooks: { user_id: current_user.id })` |
+| Examples | `Example.joins(word: :wordbook).where(wordbooks: { user_id: current_user.id })` |
+| Settings | `current_user.setting` |
+
+他ユーザーのリソースにアクセスした場合は`404 Not Found`を返却（リソースの存在を漏らさないため）。
+
+## エラーレスポンス
+
+| ステータス | 条件 | レスポンス |
+|-----------|------|-----------|
+| 401 Unauthorized | トークンなし / 無効なトークン / 期限切れ | `{ "error": "Unauthorized" }` |
+| 404 Not Found | リソースが存在しない / 他ユーザーのリソース | `{ "error": "Not found" }` |

--- a/docs/guest_migration.md
+++ b/docs/guest_migration.md
@@ -1,0 +1,134 @@
+# ゲストユーザーデータの引き継ぎ（Guest Migration）
+
+## 概要
+
+ゲストユーザーが Google アカウントで本登録する際、ゲスト期間中に作成したデータを引き継ぐ機能。
+
+### 引き継ぎ対象データ
+
+- 単語帳（Wordbooks）
+- 単語（Words）— ステータス、次回復習日を含む
+- 意味（Meanings）
+- 例文（Examples）
+- 学習設定（Settings）— 復習間隔のカスタマイズ
+
+## API 仕様
+
+### エンドポイント
+
+`POST /api/v1/auth/google`（既存の Google 認証エンドポイントを拡張）
+
+### リクエスト
+
+```
+POST /api/v1/auth/google
+Authorization: Bearer <GOOGLE_ID_TOKEN>
+Content-Type: application/json
+
+{
+  "guest_token": "<GUEST_JWT>"
+}
+```
+
+- `Authorization` ヘッダー: Google ID トークン（必須、通常の Google 認証と同じ）
+- `guest_token`: ゲストユーザーの JWT トークン（オプション。指定時にデータ移行を実行）
+
+### レスポンス
+
+**成功時（200 OK）:**
+
+```json
+{
+  "user": {
+    "email": "user@example.com",
+    "name": "User Name",
+    "avatar_url": "https://example.com/avatar.jpg"
+  },
+  "token": "<NEW_JWT>"
+}
+```
+
+**エラー時:**
+
+| ステータス | 条件 | レスポンス |
+|-----------|------|-----------|
+| 400 Bad Request | Authorization ヘッダーなし | `{ "error": "Authorization header missing" }` |
+| 401 Unauthorized | Google ID トークンが無効 | `{ "error": "Invalid ID token" }` |
+| 401 Unauthorized | guest_token が無効 / ゲストユーザーが見つからない | `{ "error": "Invalid guest token" }` |
+| 422 Unprocessable Entity | guest_token のユーザーがゲストでない | `{ "error": "User is not a guest" }` |
+
+## 処理フロー
+
+### シナリオ A: インプレース変換（Google アカウント未登録の場合）
+
+最も一般的なケース。ゲストユーザーが初めて Google アカウントを登録する場合。
+
+```
+Guest User (id=1, provider="guest")
+  ↓ update!
+Google User (id=1, provider="google", provider_uid="sub値", email="...")
+```
+
+- User レコードの `provider`、`provider_uid`、`email`、`name`、`avatar_url` を更新
+- `guest_expires_at` を `nil` に設定
+- `user_id` は変わらないため、関連データ（Wordbooks 以下全て）はそのまま保持
+- User 数は変化しない
+
+### シナリオ B: マージ（Google アカウント既に存在する場合）
+
+別デバイスで先に Google 登録済みのユーザーがゲスト端末のデータを取り込むケース。
+
+```
+Guest User (id=1)              Google User (id=2)
+  ├── Wordbook A                 ├── Wordbook X
+  ├── Wordbook B                 └── Setting
+  └── Setting
+          ↓ マージ
+Google User (id=2)
+  ├── Wordbook X（既存）
+  ├── Wordbook A（移行）
+  ├── Wordbook B（移行）
+  └── Setting（既存を維持）
+```
+
+- ゲストの Wordbooks を Google ユーザーに `user_id` を付け替え（`update_all`）
+- Words / Meanings / Examples は `wordbook_id` 経由の FK で自動的に追随
+- Settings: Google ユーザーに設定がなければ移行、あれば既存を維持
+- ゲストユーザーを削除
+- User 数が 1 減少
+
+## 実装詳細
+
+### 主要ファイル
+
+| ファイル | 役割 |
+|---------|------|
+| `app/controllers/concerns/guest_migratable.rb` | 移行ロジック（Concern） |
+| `app/controllers/api/v1/auth_controller.rb` | エンドポイント（`google` アクション内で分岐） |
+
+### DB 制約との互換性
+
+インプレース変換時、以下の CHECK 制約はすべて満たされる：
+
+| 制約 | 変換後の状態 | 結果 |
+|------|------------|------|
+| `provider IN ('google', 'guest')` | `'google'` | OK |
+| `provider = 'guest' OR provider_uid IS NOT NULL` | `'google'` + `provider_uid` あり | OK |
+| `provider != 'guest' OR guest_expires_at IS NOT NULL` | `'google'` → 条件不問 | OK |
+| UNIQUE `(provider, provider_uid)` | 新しい組み合わせ → OK / 既存あり → マージへ | OK |
+| UNIQUE `email` | 新しい email → OK / 既存あり → マージへ | OK |
+
+DB マイグレーションは不要。
+
+### トランザクション
+
+全移行処理は `ActiveRecord::Base.transaction` で囲まれており、途中でエラーが発生した場合は全変更がロールバックされる。
+
+## エッジケース
+
+| ケース | 挙動 |
+|--------|------|
+| ゲストの有効期限切れ | JWT 自体が期限切れのため、`find_guest_user_from_token` で nil → 401 |
+| 同じゲストから2回リクエスト | 1回目で provider が `google` に変更済み → 2回目は `find_guest_user_from_token` で guest ユーザーが見つからず 401 |
+| Google ユーザーが guest_token を送信 | `find_guest_user_from_token` は `provider: "guest"` で検索するため nil → 401 |
+| guest_token なしで通常の Google 認証 | 既存動作がそのまま維持される（回帰なし） |

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -14,7 +14,7 @@ paths:
     post:
       tags: [Auth]
       summary: Create a guest user
-      description: Creates a temporary guest user (expires in 7 days) and returns a signed token.
+      description: Creates a temporary guest user (expires in 7 days) and returns a JWT token.
       responses:
         "201":
           description: Guest user created
@@ -32,7 +32,7 @@ paths:
                         description: Expiration time for the guest user (7 days after creation)
                   token:
                     type: string
-                    description: Signed guest token for subsequent requests
+                    description: JWT token for subsequent requests (expires at guest_expires_at)
 
   /api/v1/auth/google:
     post:
@@ -40,9 +40,25 @@ paths:
       summary: Authenticate with Google
       description: |
         Verifies a Google ID token and finds or creates the user.
+        Returns a JWT token for subsequent API requests.
         If the email is already registered with a different provider, returns 409 Conflict.
+
+        **Guest migration:** When `guest_token` is provided in the request body,
+        migrates the guest user's data (wordbooks, words, meanings, examples, settings)
+        to the Google account. If the Google account already exists, guest data is merged
+        into it; otherwise, the guest user record is converted in-place.
       security:
         - googleIdToken: []
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                guest_token:
+                  type: string
+                  description: JWT token of the guest user to migrate data from (optional)
       responses:
         "200":
           description: Authentication successful
@@ -62,6 +78,9 @@ paths:
                       avatar_url:
                         type: string
                         nullable: true
+                  token:
+                    type: string
+                    description: JWT token for subsequent requests (expires in 30 days)
         "400":
           description: Authorization header missing
           content:
@@ -80,12 +99,20 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        "422":
+          description: Guest migration failed (e.g., guest_token user is not a guest)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 
   # ──────────────── Wordbooks ────────────────
   /api/v1/wordbooks:
     get:
       tags: [Wordbooks]
-      summary: List all wordbooks
+      summary: List current user's wordbooks
+      security:
+        - bearerAuth: []
       responses:
         "200":
           description: OK
@@ -95,9 +122,13 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Wordbook"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
     post:
       tags: [Wordbooks]
       summary: Create a wordbook
+      security:
+        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -119,6 +150,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Wordbook"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         "422":
           description: Validation error
           content:
@@ -132,6 +165,8 @@ paths:
     get:
       tags: [Wordbooks]
       summary: Get a wordbook
+      security:
+        - bearerAuth: []
       responses:
         "200":
           description: OK
@@ -139,9 +174,15 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Wordbook"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
     patch:
       tags: [Wordbooks]
       summary: Update a wordbook
+      security:
+        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -162,6 +203,10 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Wordbook"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
         "422":
           description: Validation error
           content:
@@ -171,15 +216,23 @@ paths:
     delete:
       tags: [Wordbooks]
       summary: Delete a wordbook
+      security:
+        - bearerAuth: []
       responses:
         "204":
           description: No Content
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
 
   # ──────────────── Words ────────────────
   /api/v1/words:
     get:
       tags: [Words]
-      summary: List all words
+      summary: List current user's words
+      security:
+        - bearerAuth: []
       responses:
         "200":
           description: OK
@@ -189,9 +242,13 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Word"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
     post:
       tags: [Words]
       summary: Create a word
+      security:
+        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -221,6 +278,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Word"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         "422":
           description: Validation error
           content:
@@ -234,6 +293,8 @@ paths:
     get:
       tags: [Words]
       summary: Get a word
+      security:
+        - bearerAuth: []
       responses:
         "200":
           description: OK
@@ -241,9 +302,15 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Word"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
     patch:
       tags: [Words]
       summary: Update a word
+      security:
+        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -255,8 +322,6 @@ paths:
                 word:
                   type: object
                   properties:
-                    wordbook_id:
-                      type: integer
                     spelling:
                       type: string
                     status:
@@ -272,6 +337,10 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Word"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
         "422":
           description: Validation error
           content:
@@ -281,15 +350,23 @@ paths:
     delete:
       tags: [Words]
       summary: Delete a word
+      security:
+        - bearerAuth: []
       responses:
         "204":
           description: No Content
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
 
   # ──────────────── Meanings ────────────────
   /api/v1/meanings:
     get:
       tags: [Meanings]
-      summary: List all meanings
+      summary: List current user's meanings
+      security:
+        - bearerAuth: []
       responses:
         "200":
           description: OK
@@ -299,9 +376,13 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Meaning"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
     post:
       tags: [Meanings]
       summary: Create a meaning
+      security:
+        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -328,6 +409,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Meaning"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         "422":
           description: Validation error
           content:
@@ -341,6 +424,8 @@ paths:
     get:
       tags: [Meanings]
       summary: Get a meaning
+      security:
+        - bearerAuth: []
       responses:
         "200":
           description: OK
@@ -348,9 +433,15 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Meaning"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
     patch:
       tags: [Meanings]
       summary: Update a meaning
+      security:
+        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -362,8 +453,6 @@ paths:
                 meaning:
                   type: object
                   properties:
-                    word_id:
-                      type: integer
                     content:
                       type: string
                     display_order:
@@ -376,6 +465,10 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Meaning"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
         "422":
           description: Validation error
           content:
@@ -385,15 +478,23 @@ paths:
     delete:
       tags: [Meanings]
       summary: Delete a meaning
+      security:
+        - bearerAuth: []
       responses:
         "204":
           description: No Content
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
 
   # ──────────────── Examples ────────────────
   /api/v1/examples:
     get:
       tags: [Examples]
-      summary: List all examples
+      summary: List current user's examples
+      security:
+        - bearerAuth: []
       responses:
         "200":
           description: OK
@@ -403,9 +504,13 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Example"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
     post:
       tags: [Examples]
       summary: Create an example
+      security:
+        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -434,6 +539,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Example"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         "422":
           description: Validation error
           content:
@@ -447,6 +554,8 @@ paths:
     get:
       tags: [Examples]
       summary: Get an example
+      security:
+        - bearerAuth: []
       responses:
         "200":
           description: OK
@@ -454,9 +563,15 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Example"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
     patch:
       tags: [Examples]
       summary: Update an example
+      security:
+        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -468,8 +583,6 @@ paths:
                 example:
                   type: object
                   properties:
-                    word_id:
-                      type: integer
                     sentence:
                       type: string
                     translation:
@@ -484,6 +597,10 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Example"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
         "422":
           description: Validation error
           content:
@@ -493,15 +610,23 @@ paths:
     delete:
       tags: [Examples]
       summary: Delete an example
+      security:
+        - bearerAuth: []
       responses:
         "204":
           description: No Content
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
 
   # ──────────────── Settings ────────────────
   /api/v1/settings:
     get:
       tags: [Settings]
-      summary: List all settings
+      summary: List current user's settings
+      security:
+        - bearerAuth: []
       responses:
         "200":
           description: OK
@@ -511,9 +636,13 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Setting"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
     post:
       tags: [Settings]
       summary: Create a setting
+      security:
+        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -539,6 +668,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Setting"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         "422":
           description: Validation error
           content:
@@ -552,6 +683,8 @@ paths:
     get:
       tags: [Settings]
       summary: Get a setting
+      security:
+        - bearerAuth: []
       responses:
         "200":
           description: OK
@@ -559,9 +692,15 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Setting"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
     patch:
       tags: [Settings]
       summary: Update a setting
+      security:
+        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -586,6 +725,10 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Setting"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
         "422":
           description: Validation error
           content:
@@ -595,9 +738,15 @@ paths:
     delete:
       tags: [Settings]
       summary: Delete a setting
+      security:
+        - bearerAuth: []
       responses:
         "204":
           description: No Content
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
 
 components:
   securitySchemes:
@@ -605,6 +754,11 @@ components:
       type: http
       scheme: bearer
       description: Google ID token passed as Bearer token in Authorization header
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: JWT token obtained from /api/v1/auth/guest or /api/v1/auth/google
 
   parameters:
     Id:
@@ -613,6 +767,20 @@ components:
       required: true
       schema:
         type: integer
+
+  responses:
+    Unauthorized:
+      description: Authentication required or invalid token
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    NotFound:
+      description: Resource not found or not owned by current user
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
 
   schemas:
     # ──── Models ────
@@ -626,6 +794,7 @@ components:
           enum: [google, guest]
         provider_uid:
           type: string
+          nullable: true
         email:
           type: string
           nullable: true

--- a/src/app/(authenticated)/dashboard/page.tsx
+++ b/src/app/(authenticated)/dashboard/page.tsx
@@ -1,3 +1,4 @@
+import { GuestMigrationBanner } from '@/components/auth/guest-migration-banner';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { WordbookList } from '@/components/wordbook/wordbook-list';
@@ -14,7 +15,10 @@ export default function DashboardPage() {
   return (
     <div className="min-h-screen bg-background">
       <div className="max-w-4xl mx-auto px-4 py-8">
-        <div className="flex items-center justify-between mb-8">
+        <Suspense>
+          <GuestMigrationBanner />
+        </Suspense>
+        <div className="flex items-center justify-between mb-8 mt-6">
           <h1 className="text-3xl font-bold">単語帳</h1>
           <Button asChild>
             <Link href="/wordbooks/new">

--- a/src/components/auth/guest-migration-banner.tsx
+++ b/src/components/auth/guest-migration-banner.tsx
@@ -1,0 +1,38 @@
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { migrateGuestToGoogleAction } from '@/lib/actions/guest-actions';
+import { auth } from '@/lib/auth';
+import { FcGoogle } from 'react-icons/fc';
+
+export async function GuestMigrationBanner() {
+  const session = await auth();
+
+  if (session?.user?.isGuest !== true) {
+    return null;
+  }
+
+  return (
+    <Card className="border-amber-300 bg-amber-50 dark:border-amber-700 dark:bg-amber-950">
+      <CardContent className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="font-medium text-amber-900 dark:text-amber-100">
+            ゲストアカウントをご利用中です
+          </p>
+          <p className="text-sm text-amber-700 dark:text-amber-300">
+            ゲストアカウントには7日間の有効期限があります。Googleアカウントで登録すると、データを永続的に保存できます。
+          </p>
+        </div>
+        <form action={migrateGuestToGoogleAction}>
+          <Button
+            type="submit"
+            variant="outline"
+            className="shrink-0 border-amber-400 text-amber-900 hover:bg-amber-100 dark:border-amber-600 dark:text-amber-100 dark:hover:bg-amber-900"
+          >
+            <FcGoogle className="mr-2 h-4 w-4" />
+            Googleで登録
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/layout/guest-sign-out-dialog.tsx
+++ b/src/components/layout/guest-sign-out-dialog.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
+import { migrateGuestToGoogleAction } from '@/lib/actions/guest-actions';
+import { signOutAction } from '@/lib/auth/actions';
+import { useTransition } from 'react';
+
+export function GuestSignOutDialog() {
+  const [isMigrating, startMigration] = useTransition();
+  const [isSigningOut, startSignOut] = useTransition();
+
+  function handleMigrate() {
+    startMigration(async () => {
+      await migrateGuestToGoogleAction();
+    });
+  }
+
+  function handleSignOut() {
+    startSignOut(async () => {
+      await signOutAction();
+    });
+  }
+
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
+          ログアウト
+        </DropdownMenuItem>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>ログアウトしますか？</AlertDialogTitle>
+          <AlertDialogDescription>
+            ゲストアカウントのデータは再ログインで復元できません。Googleアカウントで登録すると、データを永続的に保存できます。
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>キャンセル</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleMigrate}
+            disabled={isMigrating || isSigningOut}
+          >
+            {isMigrating ? '処理中...' : 'Googleで登録'}
+          </AlertDialogAction>
+          <AlertDialogAction
+            onClick={handleSignOut}
+            disabled={isMigrating || isSigningOut}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            {isSigningOut ? 'ログアウト中...' : 'ログアウト'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/layout/user-menu-presenter.tsx
+++ b/src/components/layout/user-menu-presenter.tsx
@@ -1,4 +1,5 @@
 import { Avatar, AvatarImage } from '@/components/ui/avatar';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -8,23 +9,24 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { migrateGuestToGoogleAction } from '@/lib/actions/guest-actions';
 import { signOutAction } from '@/lib/auth/actions';
 import Link from 'next/link';
+import { GuestSignOutDialog } from './guest-sign-out-dialog';
 
 type UserMenuPresenterProps = {
   name: string | null | undefined;
   email: string | null | undefined;
   image: string | null | undefined;
+  isGuest: boolean;
 };
 
-// eslint-disable-next-line @typescript-eslint/require-await
-export async function UserMenuPresenter({
+export function UserMenuPresenter({
   name,
   email,
   image,
+  isGuest,
 }: UserMenuPresenterProps) {
-  'use cache';
-
   if (name === null || name === undefined) {
     return (
       <Button asChild variant="ghost">
@@ -48,8 +50,16 @@ export async function UserMenuPresenter({
       <DropdownMenuContent align="end" className="w-56">
         <DropdownMenuLabel>
           <div className="flex flex-col space-y-1">
-            <p className="text-sm font-medium">{name}</p>
-            <p className="text-xs text-muted-foreground">{email}</p>
+            {isGuest ? (
+              <Badge variant="secondary" className="text-xs w-fit">
+                ゲスト
+              </Badge>
+            ) : (
+              <p className="text-sm font-medium">{name}</p>
+            )}
+            <p className="text-xs text-muted-foreground">
+              {isGuest ? '7日間の有効期限があります' : email}
+            </p>
           </div>
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
@@ -59,14 +69,30 @@ export async function UserMenuPresenter({
         <DropdownMenuItem asChild>
           <Link href="/settings">設定</Link>
         </DropdownMenuItem>
+        {isGuest && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem asChild>
+              <form action={migrateGuestToGoogleAction} className="w-full">
+                <button type="submit" className="w-full text-left">
+                  Googleで登録
+                </button>
+              </form>
+            </DropdownMenuItem>
+          </>
+        )}
         <DropdownMenuSeparator />
-        <DropdownMenuItem asChild>
-          <form action={signOutAction} className="w-full">
-            <button type="submit" className="w-full text-left">
-              ログアウト
-            </button>
-          </form>
-        </DropdownMenuItem>
+        {isGuest ? (
+          <GuestSignOutDialog />
+        ) : (
+          <DropdownMenuItem asChild>
+            <form action={signOutAction} className="w-full">
+              <button type="submit" className="w-full text-left">
+                ログアウト
+              </button>
+            </form>
+          </DropdownMenuItem>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/src/components/layout/user-menu.tsx
+++ b/src/components/layout/user-menu.tsx
@@ -6,6 +6,14 @@ export async function UserMenu() {
   const name = session?.user?.name;
   const email = session?.user?.email;
   const image = session?.user?.image;
+  const isGuest = session?.user?.isGuest ?? false;
 
-  return <UserMenuPresenter name={name} email={email} image={image} />;
+  return (
+    <UserMenuPresenter
+      name={name}
+      email={email}
+      image={image}
+      isGuest={isGuest}
+    />
+  );
 }

--- a/src/lib/actions/guest-actions.ts
+++ b/src/lib/actions/guest-actions.ts
@@ -1,12 +1,40 @@
 'use server';
 
-import { signIn } from '@/lib/auth';
+import { auth, signIn } from '@/lib/auth';
+import { setGuestTokenCookie } from '@/lib/auth/guest-migration';
 import { AuthError } from 'next-auth';
 import { redirect } from 'next/navigation';
 
 export async function signInAsGuestAction() {
   try {
     await signIn('guest', {
+      redirectTo: '/dashboard',
+    });
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return redirect(`/auth?error=${error.type}`);
+    }
+    throw error;
+  }
+}
+
+export async function migrateGuestToGoogleAction() {
+  const session = await auth();
+
+  if (session?.user?.isGuest !== true) {
+    throw new Error('Only guest users can migrate');
+  }
+
+  const accessToken = session.user.accessToken;
+
+  if (accessToken === undefined) {
+    throw new Error('Guest access token is missing');
+  }
+
+  await setGuestTokenCookie(accessToken);
+
+  try {
+    await signIn('google', {
       redirectTo: '/dashboard',
     });
   } catch (error) {

--- a/src/lib/auth/guest-migration.ts
+++ b/src/lib/auth/guest-migration.ts
@@ -1,0 +1,28 @@
+import 'server-only';
+
+import { cookies } from 'next/headers';
+
+const COOKIE_NAME = 'guest_migration_token';
+
+export async function setGuestTokenCookie(token: string): Promise<void> {
+  const cookieStore = await cookies();
+  cookieStore.set(COOKIE_NAME, token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    maxAge: 600,
+    path: '/',
+  });
+}
+
+export async function getAndClearGuestTokenCookie(): Promise<string | undefined> {
+  const cookieStore = await cookies();
+  const cookie = cookieStore.get(COOKIE_NAME);
+
+  if (cookie === undefined) {
+    return undefined;
+  }
+
+  cookieStore.delete(COOKIE_NAME);
+  return cookie.value;
+}

--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -2,6 +2,7 @@ import NextAuth from 'next-auth';
 import type { Provider } from 'next-auth/providers';
 import Credentials from 'next-auth/providers/credentials';
 import { createGuestUser } from '@/data/guest-user';
+import { getAndClearGuestTokenCookie } from './guest-migration';
 import { getAuthJsProviders } from './providers';
 
 const oauthProviders: Provider[] = getAuthJsProviders();
@@ -35,6 +36,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           accessToken?: string;
         };
         token.accessToken = guestUser.accessToken;
+        token.isGuest = true;
         return token;
       }
 
@@ -51,12 +53,20 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           throw new Error('API_URL is not configured');
         }
 
+        const guestToken = await getAndClearGuestTokenCookie();
+
         try {
           const response = await fetch(`${apiUrl}/auth/google`, {
             method: 'POST',
             headers: {
               Authorization: `Bearer ${googleIdToken}`,
+              ...(guestToken !== undefined
+                ? { 'Content-Type': 'application/json' }
+                : {}),
             },
+            ...(guestToken !== undefined
+              ? { body: JSON.stringify({ guest_token: guestToken }) }
+              : {}),
           });
 
           if (!response.ok) {
@@ -72,6 +82,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
             token: string;
           };
           token.accessToken = result.token;
+          token.isGuest = false;
         } catch (error) {
           console.error('API connection error:', error);
           throw error;
@@ -82,6 +93,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     },
     session({ session, token }) {
       session.user.accessToken = token.accessToken;
+      session.user.isGuest = token.isGuest ?? false;
 
       return session;
     },

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -4,6 +4,7 @@ import 'next-auth/jwt';
 declare module 'next-auth/jwt' {
   interface JWT {
     accessToken?: string;
+    isGuest?: boolean;
   }
 }
 
@@ -11,6 +12,7 @@ declare module 'next-auth' {
   interface Session {
     user: {
       accessToken?: string;
+      isGuest?: boolean;
     } & DefaultSession['user'];
   }
 }


### PR DESCRIPTION
## Summary

- Store Rails API JWT as session `accessToken` instead of Google ID token, so all downstream API calls use the correct token
- Update OpenAPI spec with bearer auth security schemes, guest migration endpoint (`guest_token` parameter), and missing 401/404 responses
- Add `isGuest` flag to NextAuth JWT/session for guest user detection
- Implement cookie-based guest token handoff: before Google OAuth redirect, the guest JWT is saved to an HTTP-only cookie, then read in the JWT callback and sent as `guest_token` to `POST /api/v1/auth/google`
- Add migration banner on dashboard and "Google で登録" option in user menu for guest users
- Add guest sign-out confirmation dialog warning about data loss with option to migrate instead

## Changes

### Auth
- `src/types/next-auth.d.ts`: Add `isGuest` to JWT and Session types
- `src/lib/auth/guest-migration.ts`: Cookie utilities for guest token handoff (`setGuestTokenCookie`, `getAndClearGuestTokenCookie`)
- `src/lib/auth/index.ts`: Set `isGuest` in JWT callback; send `guest_token` to Rails API on Google sign-in if migration cookie exists
- `src/lib/actions/guest-actions.ts`: Add `migrateGuestToGoogleAction` server action

### UI
- `src/components/auth/guest-migration-banner.tsx`: Amber-styled banner on dashboard for guest users
- `src/components/layout/guest-sign-out-dialog.tsx`: Confirmation dialog with "Google で登録" / "ログアウト" / "キャンセル"
- `src/components/layout/user-menu.tsx` / `user-menu-presenter.tsx`: Show guest badge, expiry info, migration option in dropdown
- `src/app/(authenticated)/dashboard/page.tsx`: Add migration banner with Suspense

### Docs
- `docs/openapi.yaml`: Security schemes, guest migration, 401/404 responses
- `docs/authentication.md`, `docs/guest_migration.md`: Auth flow and migration documentation

## Test plan

- [x] Sign in as guest → create a wordbook → verify migration banner appears on dashboard
- [x] Click "Google で登録" from banner or user menu → complete Google OAuth → verify guest data is preserved
- [x] As guest, click "ログアウト" in user menu → verify confirmation dialog appears with migration option
- [x] Sign in as Google user → verify no banner or guest UI appears
- [x] `pnpm lint` and `pnpm build` pass without errors
