### PR TITLE
chore: add workflow guidelines and commit/PR skill definitions

### DIFF
--- a/.claude/skills/git-commit/SKILL.md
+++ b/.claude/skills/git-commit/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: git-commit
+description: Git commit rules and conventions. Follow these when creating any git commit or planning commit strategy.
+allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git diff:*), AskUserQuestion
+---
+
+## Commit Message Rules
+
+- Write in English
+- Use the Conventional Commits format: `<type>: <description>`
+  - Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`
+- Keep the subject line under 72 characters
+- Do NOT include `Co-Authored-By` or any AI attribution
+
+## Commit Grouping Guidelines
+
+When multiple files are changed, group them into logical commits:
+
+- Group files that serve the same purpose
+- If there is only one file changed or all changes are clearly related, use a single commit
+
+## Commit Workflow
+
+When invoked directly, execute the following workflow.
+
+### Context
+
+- Current git status: !`git status`
+- Current git diff (uncommitted changes): !`git diff HEAD`
+- Current branch: !`git branch --show-current`
+
+### Pre-check
+
+- If there are no uncommitted changes, inform the user and stop. Do NOT proceed.
+- Show the current branch name to the user and use AskUserQuestion to confirm:
+  - "Continue on this branch"
+  - "Stop" (user will switch branches manually)
+
+### 1. Analyze changes and propose commit groups
+
+Examine the diff and group changes into logical commits following the Commit Grouping Guidelines above.
+
+Present your proposed groupings to the user as a numbered list showing files and commit message per group. Then use AskUserQuestion to confirm:
+
+- "Proceed as proposed"
+- "Combine into one commit"
+- "Let me regroup" (user describes preferred grouping via Other)
+
+If the user selects "Let me regroup", revise the groupings based on their input and re-confirm.
+
+### 2. Commit
+
+For each commit group (in the confirmed order):
+
+- Stage only the files in that group with `git add`
+- Create a commit following the Commit Message Rules above

--- a/.claude/skills/pull-request/SKILL.md
+++ b/.claude/skills/pull-request/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: pull-request
+description: PR creation rules and conventions. Follow these when creating a pull request.
+allowed-tools: Bash(git push:*), Bash(git log:*), Bash(git branch:*), Bash(git status:*), Bash(git diff:*), Bash(gh pr create:*), AskUserQuestion
+---
+
+## PR Title Rules
+
+- Write in English
+- Use the Conventional Commits format: `<type>: <description>`
+  - Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`
+- Keep the title under 72 characters
+
+## PR Body Template
+
+```
+## Summary
+- <bullet point describing the change>
+```
+
+- Write the summary in English
+- Use concise bullet points (1-3 items)
+- Focus on **what** changed and **why**, not implementation details
+
+## PR Workflow
+
+When invoked directly, execute the following workflow.
+
+### Context
+
+- Current branch: !`git branch --show-current`
+- Commits on this branch (vs main): !`git log main..HEAD --oneline`
+
+### Pre-check
+
+- If the current branch is `main`, inform the user and stop. Do NOT proceed.
+- If there are no commits ahead of main, inform the user and stop. Do NOT proceed.
+- Show the branch name and commit list to the user and use AskUserQuestion to confirm:
+  - "Create PR"
+  - "Stop"
+
+### 1. Push and create PR
+
+- Push the branch to remote: `git push -u origin <branch>`
+- Create the PR with `gh pr create` targeting `main`, using the title and body rules above
+- Display the created PR URL to the user

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ WordBeetle Frontend — a Next.js 16 (App Router) application with React 19, Typ
 ## Commands
 
 - `pnpm install` — install dependencies (pnpm is enforced via preinstall script)
-- `pnpm dev` — start dev server (http://localhost:3000)
+- `pnpm dev` — start dev server (<http://localhost:3000>)
 - `pnpm build` — production build
 - `pnpm lint` — run ESLint
 
@@ -81,6 +81,7 @@ src/
 ## Code Style & Lint Rules
 
 **ESLint** (flat config, `eslint.config.mjs`):
+
 - `@typescript-eslint/strict-boolean-expressions` — no truthy/falsy coercion; use explicit comparisons (e.g., `!== undefined`, `!== null`)
 - `@typescript-eslint/switch-exhaustiveness-check` — no default case for exhaustive switches
 - `no-implicit-coercion` — no `!!`, `+""`, etc.
@@ -93,6 +94,7 @@ src/
 ## Environment Variables
 
 Required in `.env.local`:
+
 - `AUTH_SECRET` — NextAuth secret
 - `AUTH_GOOGLE_ID` / `AUTH_GOOGLE_SECRET` — Google OAuth credentials
 - `API_URL` — Rails backend base URL
@@ -100,3 +102,12 @@ Required in `.env.local`:
 ## Path Aliases
 
 `@/*` maps to `./src/*` (configured in `tsconfig.json`).
+
+## Workflow
+
+- Before starting implementation, enter plan mode to design the approach and align with the user.
+  - The plan must include a commit strategy: define how to group changes into logical commits and a draft commit message for each.
+- When beginning work, always pull the latest main branch and create a new branch with an appropriate name before making any changes.
+- During implementation, commit incrementally according to the plan. Create each commit as soon as the corresponding unit of work is complete, rather than batching all commits at the end.
+- When committing, follow the rules defined in `.claude/skills/git-commit/SKILL.md`.
+- After all implementation is complete, push the branch and create a PR following the rules in `.claude/skills/pull-request/SKILL.md`.


### PR DESCRIPTION
## Summary
- Add Workflow section to CLAUDE.md with guidelines for planning, branching, incremental commits, and PR creation
- Add Claude Code skill definitions for git-commit and pull-request conventions (`.claude/skills/`)
- Minor CLAUDE.md formatting fixes (markdown link syntax, blank lines before lists)
