### PR TITLE
refactor: migrate API layer to nested endpoints

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -150,6 +150,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Wordbook"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "422":
@@ -203,6 +205,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Wordbook"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "404":
@@ -227,10 +231,12 @@ paths:
           $ref: "#/components/responses/NotFound"
 
   # ──────────────── Words ────────────────
-  /api/v1/words:
+  /api/v1/wordbooks/{wordbook_id}/words:
+    parameters:
+      - $ref: "#/components/parameters/WordbookId"
     get:
       tags: [Words]
-      summary: List current user's words
+      summary: List words in a wordbook
       security:
         - bearerAuth: []
       responses:
@@ -244,9 +250,11 @@ paths:
                   $ref: "#/components/schemas/Word"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
     post:
       tags: [Words]
-      summary: Create a word
+      summary: Create a word in a wordbook
       security:
         - bearerAuth: []
       requestBody:
@@ -259,10 +267,8 @@ paths:
               properties:
                 word:
                   type: object
-                  required: [wordbook_id, spelling, status]
+                  required: [spelling, status]
                   properties:
-                    wordbook_id:
-                      type: integer
                     spelling:
                       type: string
                     status:
@@ -278,8 +284,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Word"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
         "422":
           description: Validation error
           content:
@@ -287,8 +297,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ValidationErrors"
 
-  /api/v1/words/{id}:
+  /api/v1/wordbooks/{wordbook_id}/words/{id}:
     parameters:
+      - $ref: "#/components/parameters/WordbookId"
       - $ref: "#/components/parameters/Id"
     get:
       tags: [Words]
@@ -337,6 +348,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Word"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "404":
@@ -361,10 +374,13 @@ paths:
           $ref: "#/components/responses/NotFound"
 
   # ──────────────── Meanings ────────────────
-  /api/v1/meanings:
+  /api/v1/wordbooks/{wordbook_id}/words/{word_id}/meanings:
+    parameters:
+      - $ref: "#/components/parameters/WordbookId"
+      - $ref: "#/components/parameters/WordId"
     get:
       tags: [Meanings]
-      summary: List current user's meanings
+      summary: List meanings for a word
       security:
         - bearerAuth: []
       responses:
@@ -378,9 +394,11 @@ paths:
                   $ref: "#/components/schemas/Meaning"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
     post:
       tags: [Meanings]
-      summary: Create a meaning
+      summary: Create a meaning for a word
       security:
         - bearerAuth: []
       requestBody:
@@ -393,10 +411,8 @@ paths:
               properties:
                 meaning:
                   type: object
-                  required: [word_id, content, display_order]
+                  required: [content, display_order]
                   properties:
-                    word_id:
-                      type: integer
                     content:
                       type: string
                     display_order:
@@ -409,8 +425,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Meaning"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
         "422":
           description: Validation error
           content:
@@ -418,8 +438,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/ValidationErrors"
 
-  /api/v1/meanings/{id}:
+  /api/v1/wordbooks/{wordbook_id}/words/{word_id}/meanings/{id}:
     parameters:
+      - $ref: "#/components/parameters/WordbookId"
+      - $ref: "#/components/parameters/WordId"
       - $ref: "#/components/parameters/Id"
     get:
       tags: [Meanings]
@@ -465,6 +487,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Meaning"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "404":
@@ -489,10 +513,13 @@ paths:
           $ref: "#/components/responses/NotFound"
 
   # ──────────────── Examples ────────────────
-  /api/v1/examples:
+  /api/v1/wordbooks/{wordbook_id}/words/{word_id}/examples:
+    parameters:
+      - $ref: "#/components/parameters/WordbookId"
+      - $ref: "#/components/parameters/WordId"
     get:
       tags: [Examples]
-      summary: List current user's examples
+      summary: List examples for a word
       security:
         - bearerAuth: []
       responses:
@@ -506,9 +533,11 @@ paths:
                   $ref: "#/components/schemas/Example"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
     post:
       tags: [Examples]
-      summary: Create an example
+      summary: Create an example for a word
       security:
         - bearerAuth: []
       requestBody:
@@ -521,10 +550,8 @@ paths:
               properties:
                 example:
                   type: object
-                  required: [word_id, sentence, translation, display_order]
+                  required: [sentence, translation, display_order]
                   properties:
-                    word_id:
-                      type: integer
                     sentence:
                       type: string
                     translation:
@@ -539,8 +566,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Example"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
         "422":
           description: Validation error
           content:
@@ -548,8 +579,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/ValidationErrors"
 
-  /api/v1/examples/{id}:
+  /api/v1/wordbooks/{wordbook_id}/words/{word_id}/examples/{id}:
     parameters:
+      - $ref: "#/components/parameters/WordbookId"
+      - $ref: "#/components/parameters/WordId"
       - $ref: "#/components/parameters/Id"
     get:
       tags: [Examples]
@@ -597,6 +630,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Example"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "404":
@@ -620,11 +655,11 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
-  # ──────────────── Settings ────────────────
-  /api/v1/settings:
+  # ──────────────── Setting (singular resource) ────────────────
+  /api/v1/setting:
     get:
       tags: [Settings]
-      summary: List current user's settings
+      summary: Get the current user's setting
       security:
         - bearerAuth: []
       responses:
@@ -633,11 +668,11 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Setting"
+                $ref: "#/components/schemas/Setting"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
     post:
       tags: [Settings]
       summary: Create a setting
@@ -668,6 +703,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Setting"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "422":
@@ -676,29 +713,9 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ValidationErrors"
-
-  /api/v1/settings/{id}:
-    parameters:
-      - $ref: "#/components/parameters/Id"
-    get:
-      tags: [Settings]
-      summary: Get a setting
-      security:
-        - bearerAuth: []
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Setting"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "404":
-          $ref: "#/components/responses/NotFound"
     patch:
       tags: [Settings]
-      summary: Update a setting
+      summary: Update the setting
       security:
         - bearerAuth: []
       requestBody:
@@ -725,6 +742,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Setting"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "404":
@@ -737,7 +756,7 @@ paths:
                 $ref: "#/components/schemas/ValidationErrors"
     delete:
       tags: [Settings]
-      summary: Delete a setting
+      summary: Delete the setting
       security:
         - bearerAuth: []
       responses:
@@ -767,6 +786,18 @@ components:
       required: true
       schema:
         type: integer
+    WordbookId:
+      name: wordbook_id
+      in: path
+      required: true
+      schema:
+        type: integer
+    WordId:
+      name: word_id
+      in: path
+      required: true
+      schema:
+        type: integer
 
   responses:
     Unauthorized:
@@ -777,6 +808,24 @@ components:
             $ref: "#/components/schemas/Error"
     NotFound:
       description: Resource not found or not owned by current user
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    BadRequest:
+      description: Required parameter missing
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    Conflict:
+      description: Duplicate record
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    InternalServerError:
+      description: Unexpected server error (production only)
       content:
         application/json:
           schema:

--- a/src/app/(authenticated)/settings/page.tsx
+++ b/src/app/(authenticated)/settings/page.tsx
@@ -7,7 +7,8 @@ import {
 } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { SettingsForm } from '@/components/settings/settings-form';
-import { listSettings } from '@/lib/api/settings';
+import { ApiError } from '@/lib/api/client';
+import { getSetting } from '@/lib/api/settings';
 import type { Metadata } from 'next';
 import { Suspense } from 'react';
 
@@ -16,8 +17,16 @@ export const metadata: Metadata = {
 };
 
 async function SettingsContent() {
-  const settings = await listSettings();
-  const setting = settings[0];
+  let setting;
+  try {
+    setting = await getSetting();
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 404) {
+      setting = undefined;
+    } else {
+      throw error;
+    }
+  }
 
   return (
     <Card>

--- a/src/app/(authenticated)/wordbooks/[wordbookId]/test/page.tsx
+++ b/src/app/(authenticated)/wordbooks/[wordbookId]/test/page.tsx
@@ -26,32 +26,33 @@ async function TestContent({ wordbookId }: { wordbookId: string }) {
     notFound();
   }
 
-  const [allWords, allMeanings, allExamples] = await Promise.all([
-    listWords(),
-    listMeanings(),
-    listExamples(),
-  ]);
+  const allWords = await listWords(Number(wordbookId));
 
   const now = new Date();
-  const wordbookWords = allWords.filter((w) => {
-    if (w.wordbook_id !== wordbook.id) {
-      return false;
-    }
+  const reviewWords = allWords.filter((w) => {
     if (w.next_review_at === null) {
       return true;
     }
     return new Date(w.next_review_at) <= now;
   });
 
-  const wordsWithRelations = wordbookWords.map((word) => ({
-    word,
-    meanings: allMeanings
-      .filter((m) => m.word_id === word.id)
-      .sort((a, b) => a.display_order - b.display_order),
-    examples: allExamples
-      .filter((e) => e.word_id === word.id)
-      .sort((a, b) => a.display_order - b.display_order),
-  }));
+  const wordsWithRelations = await Promise.all(
+    reviewWords.map(async (word) => {
+      const [meanings, examples] = await Promise.all([
+        listMeanings(Number(wordbookId), word.id),
+        listExamples(Number(wordbookId), word.id),
+      ]);
+      return {
+        word,
+        meanings: meanings.sort(
+          (a, b) => a.display_order - b.display_order,
+        ),
+        examples: examples.sort(
+          (a, b) => a.display_order - b.display_order,
+        ),
+      };
+    }),
+  );
 
   return (
     <>

--- a/src/app/(authenticated)/wordbooks/[wordbookId]/words/[wordId]/edit/page.tsx
+++ b/src/app/(authenticated)/wordbooks/[wordbookId]/words/[wordId]/edit/page.tsx
@@ -1,4 +1,9 @@
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { WordForm } from '@/components/word/word-form';
 import { listExamples } from '@/lib/api/examples';
@@ -25,22 +30,22 @@ async function EditWordContent({
 }) {
   let word;
   try {
-    word = await getWord(Number(wordId));
+    word = await getWord(Number(wordbookId), Number(wordId));
   } catch {
     notFound();
   }
 
-  const [allMeanings, allExamples] = await Promise.all([
-    listMeanings(),
-    listExamples(),
+  const [meanings, examples] = await Promise.all([
+    listMeanings(Number(wordbookId), Number(wordId)),
+    listExamples(Number(wordbookId), Number(wordId)),
   ]);
 
-  const meanings = allMeanings
-    .filter((m) => m.word_id === word.id)
-    .sort((a, b) => a.display_order - b.display_order);
-  const examples = allExamples
-    .filter((e) => e.word_id === word.id)
-    .sort((a, b) => a.display_order - b.display_order);
+  const sortedMeanings = meanings.sort(
+    (a, b) => a.display_order - b.display_order,
+  );
+  const sortedExamples = examples.sort(
+    (a, b) => a.display_order - b.display_order,
+  );
 
   return (
     <Card>
@@ -51,8 +56,8 @@ async function EditWordContent({
         <WordForm
           wordbookId={Number(wordbookId)}
           word={word}
-          meaning={meanings[0]}
-          example={examples[0]}
+          meaning={sortedMeanings[0]}
+          example={sortedExamples[0]}
         />
       </CardContent>
     </Card>

--- a/src/app/(authenticated)/wordbooks/[wordbookId]/words/[wordId]/word-detail-content.tsx
+++ b/src/app/(authenticated)/wordbooks/[wordbookId]/words/[wordId]/word-detail-content.tsx
@@ -20,22 +20,22 @@ export async function WordDetailContent({
 }: WordDetailContentProps) {
   let word;
   try {
-    word = await getWord(Number(wordId));
+    word = await getWord(Number(wordbookId), Number(wordId));
   } catch {
     notFound();
   }
 
-  const [allMeanings, allExamples] = await Promise.all([
-    listMeanings(),
-    listExamples(),
+  const [meanings, examples] = await Promise.all([
+    listMeanings(Number(wordbookId), Number(wordId)),
+    listExamples(Number(wordbookId), Number(wordId)),
   ]);
 
-  const meanings = allMeanings
-    .filter((m) => m.word_id === word.id)
-    .sort((a, b) => a.display_order - b.display_order);
-  const examples = allExamples
-    .filter((e) => e.word_id === word.id)
-    .sort((a, b) => a.display_order - b.display_order);
+  const sortedMeanings = meanings.sort(
+    (a, b) => a.display_order - b.display_order,
+  );
+  const sortedExamples = examples.sort(
+    (a, b) => a.display_order - b.display_order,
+  );
 
   return (
     <>
@@ -60,7 +60,11 @@ export async function WordDetailContent({
 
       <Card>
         <CardContent className="pt-6">
-          <WordDetail word={word} meanings={meanings} examples={examples} />
+          <WordDetail
+            word={word}
+            meanings={sortedMeanings}
+            examples={sortedExamples}
+          />
         </CardContent>
       </Card>
     </>

--- a/src/components/word/word-list.tsx
+++ b/src/components/word/word-list.tsx
@@ -10,27 +10,26 @@ type WordListProps = {
 };
 
 export async function WordList({ wordbookId, status, query }: WordListProps) {
-  const [allWords, allMeanings] = await Promise.all([
-    listWords(),
-    listMeanings(),
-  ]);
+  const allWords = await listWords(wordbookId);
 
-  const wordbookWords = allWords.filter(
-    (w) => w.wordbook_id === wordbookId,
+  const meaningEntries = await Promise.all(
+    allWords.map(async (word) => {
+      const meanings = await listMeanings(wordbookId, word.id);
+      const first = meanings.sort(
+        (a, b) => a.display_order - b.display_order,
+      )[0] as Meaning | undefined;
+      return [word.id, first] as const;
+    }),
   );
 
   const meaningsByWordId = new Map<number, Meaning>();
-  for (const meaning of allMeanings) {
-    const existing = meaningsByWordId.get(meaning.word_id);
-    if (
-      existing === undefined ||
-      meaning.display_order < existing.display_order
-    ) {
-      meaningsByWordId.set(meaning.word_id, meaning);
+  for (const [wordId, meaning] of meaningEntries) {
+    if (meaning !== undefined) {
+      meaningsByWordId.set(wordId, meaning);
     }
   }
 
-  let filteredWords: Word[] = wordbookWords;
+  let filteredWords: Word[] = allWords;
 
   if (status !== undefined) {
     filteredWords = filteredWords.filter((w) => w.status === status);

--- a/src/lib/actions/settings-actions.ts
+++ b/src/lib/actions/settings-actions.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { ApiError } from '@/lib/api/client';
-import { createSetting, listSettings, updateSetting } from '@/lib/api/settings';
+import { createSetting, getSetting, updateSetting } from '@/lib/api/settings';
 import type { Interval } from '@/types/api';
 import { revalidatePath } from 'next/cache';
 
@@ -26,11 +26,19 @@ export async function saveSettingsAction(
   const easyInterval = parseInterval(formData, 'easy');
 
   try {
-    const settings = await listSettings();
-    const existing = settings[0];
+    let existing;
+    try {
+      existing = await getSetting();
+    } catch (error) {
+      if (error instanceof ApiError && error.status === 404) {
+        existing = undefined;
+      } else {
+        throw error;
+      }
+    }
 
     if (existing !== undefined) {
-      await updateSetting(existing.id, {
+      await updateSetting({
         hard_interval: hardInterval,
         uncertain_interval: uncertainInterval,
         easy_interval: easyInterval,

--- a/src/lib/actions/word-actions.ts
+++ b/src/lib/actions/word-actions.ts
@@ -4,7 +4,7 @@ import { ApiError } from '@/lib/api/client';
 import { createWord, deleteWord, updateWord } from '@/lib/api/words';
 import { createMeaning, updateMeaning } from '@/lib/api/meanings';
 import { createExample, updateExample } from '@/lib/api/examples';
-import { listSettings } from '@/lib/api/settings';
+import { getSetting } from '@/lib/api/settings';
 import type { Interval, WordStatus } from '@/types/api';
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
@@ -32,15 +32,13 @@ export async function createWordAction(
   }
 
   try {
-    const word = await createWord({
-      wordbook_id: Number(wordbookId),
+    const word = await createWord(Number(wordbookId), {
       spelling: spelling.trim(),
       status: 'not_studied',
     });
 
     if (typeof meaningContent === 'string' && meaningContent.trim() !== '') {
-      await createMeaning({
-        word_id: word.id,
+      await createMeaning(Number(wordbookId), word.id, {
         content: meaningContent.trim(),
         display_order: 1,
       });
@@ -52,8 +50,7 @@ export async function createWordAction(
       typeof exampleTranslation === 'string' &&
       exampleTranslation.trim() !== ''
     ) {
-      await createExample({
-        word_id: word.id,
+      await createExample(Number(wordbookId), word.id, {
         sentence: exampleSentence.trim(),
         translation: exampleTranslation.trim(),
         display_order: 1,
@@ -94,19 +91,23 @@ export async function updateWordAction(
   }
 
   try {
-    await updateWord(Number(wordId), {
+    await updateWord(Number(wordbookId), Number(wordId), {
       spelling: spelling.trim(),
       status: status ?? undefined,
     });
 
     if (typeof meaningContent === 'string' && meaningContent.trim() !== '') {
       if (typeof meaningId === 'string' && meaningId !== '') {
-        await updateMeaning(Number(meaningId), {
-          content: meaningContent.trim(),
-        });
+        await updateMeaning(
+          Number(wordbookId),
+          Number(wordId),
+          Number(meaningId),
+          {
+            content: meaningContent.trim(),
+          },
+        );
       } else {
-        await createMeaning({
-          word_id: Number(wordId),
+        await createMeaning(Number(wordbookId), Number(wordId), {
           content: meaningContent.trim(),
           display_order: 1,
         });
@@ -120,13 +121,17 @@ export async function updateWordAction(
       exampleTranslation.trim() !== ''
     ) {
       if (typeof exampleId === 'string' && exampleId !== '') {
-        await updateExample(Number(exampleId), {
-          sentence: exampleSentence.trim(),
-          translation: exampleTranslation.trim(),
-        });
+        await updateExample(
+          Number(wordbookId),
+          Number(wordId),
+          Number(exampleId),
+          {
+            sentence: exampleSentence.trim(),
+            translation: exampleTranslation.trim(),
+          },
+        );
       } else {
-        await createExample({
-          word_id: Number(wordId),
+        await createExample(Number(wordbookId), Number(wordId), {
           sentence: exampleSentence.trim(),
           translation: exampleTranslation.trim(),
           display_order: 1,
@@ -152,7 +157,7 @@ export async function updateWordStatusAction(
   status: WordStatus,
 ): Promise<WordActionState> {
   try {
-    await updateWord(wordId, { status });
+    await updateWord(wordbookId, wordId, { status });
     revalidatePath(`/wordbooks/${wordbookId}`);
     revalidatePath(`/wordbooks/${wordbookId}/words/${wordId}`);
     return {};
@@ -170,7 +175,7 @@ export async function deleteWordAction(
   wordbookId: number,
 ): Promise<WordActionState> {
   try {
-    await deleteWord(wordId);
+    await deleteWord(wordbookId, wordId);
     revalidatePath(`/wordbooks/${wordbookId}`);
     redirect(`/wordbooks/${wordbookId}`);
   } catch (error) {
@@ -196,8 +201,16 @@ export async function evaluateWordAction(
   evaluation: 'hard' | 'uncertain' | 'easy',
 ): Promise<WordActionState> {
   try {
-    const settings = await listSettings();
-    const setting = settings[0];
+    let setting;
+    try {
+      setting = await getSetting();
+    } catch (error) {
+      if (error instanceof ApiError && error.status === 404) {
+        setting = undefined;
+      } else {
+        throw error;
+      }
+    }
 
     let intervalMs: number;
 
@@ -223,7 +236,7 @@ export async function evaluateWordAction(
 
     const nextReviewAt = new Date(Date.now() + intervalMs).toISOString();
 
-    await updateWord(wordId, {
+    await updateWord(wordbookId, wordId, {
       status: evaluation,
       next_review_at: nextReviewAt,
     });

--- a/src/lib/api/examples.ts
+++ b/src/lib/api/examples.ts
@@ -5,33 +5,59 @@ import type {
 } from '@/types/api';
 import { apiRequest } from './client';
 
-export function listExamples(): Promise<Example[]> {
-  return apiRequest({ method: 'GET', path: '/examples' });
+export function listExamples(
+  wordbookId: number,
+  wordId: number,
+): Promise<Example[]> {
+  return apiRequest({
+    method: 'GET',
+    path: `/wordbooks/${wordbookId}/words/${wordId}/examples`,
+  });
 }
 
-export function getExample(id: number): Promise<Example> {
-  return apiRequest({ method: 'GET', path: `/examples/${id}` });
+export function getExample(
+  wordbookId: number,
+  wordId: number,
+  id: number,
+): Promise<Example> {
+  return apiRequest({
+    method: 'GET',
+    path: `/wordbooks/${wordbookId}/words/${wordId}/examples/${id}`,
+  });
 }
 
-export function createExample(input: CreateExampleInput): Promise<Example> {
+export function createExample(
+  wordbookId: number,
+  wordId: number,
+  input: CreateExampleInput,
+): Promise<Example> {
   return apiRequest({
     method: 'POST',
-    path: '/examples',
+    path: `/wordbooks/${wordbookId}/words/${wordId}/examples`,
     body: { example: input },
   });
 }
 
 export function updateExample(
+  wordbookId: number,
+  wordId: number,
   id: number,
   input: UpdateExampleInput,
 ): Promise<Example> {
   return apiRequest({
     method: 'PATCH',
-    path: `/examples/${id}`,
+    path: `/wordbooks/${wordbookId}/words/${wordId}/examples/${id}`,
     body: { example: input },
   });
 }
 
-export function deleteExample(id: number): Promise<void> {
-  return apiRequest({ method: 'DELETE', path: `/examples/${id}` });
+export function deleteExample(
+  wordbookId: number,
+  wordId: number,
+  id: number,
+): Promise<void> {
+  return apiRequest({
+    method: 'DELETE',
+    path: `/wordbooks/${wordbookId}/words/${wordId}/examples/${id}`,
+  });
 }

--- a/src/lib/api/meanings.ts
+++ b/src/lib/api/meanings.ts
@@ -5,33 +5,59 @@ import type {
 } from '@/types/api';
 import { apiRequest } from './client';
 
-export function listMeanings(): Promise<Meaning[]> {
-  return apiRequest({ method: 'GET', path: '/meanings' });
+export function listMeanings(
+  wordbookId: number,
+  wordId: number,
+): Promise<Meaning[]> {
+  return apiRequest({
+    method: 'GET',
+    path: `/wordbooks/${wordbookId}/words/${wordId}/meanings`,
+  });
 }
 
-export function getMeaning(id: number): Promise<Meaning> {
-  return apiRequest({ method: 'GET', path: `/meanings/${id}` });
+export function getMeaning(
+  wordbookId: number,
+  wordId: number,
+  id: number,
+): Promise<Meaning> {
+  return apiRequest({
+    method: 'GET',
+    path: `/wordbooks/${wordbookId}/words/${wordId}/meanings/${id}`,
+  });
 }
 
-export function createMeaning(input: CreateMeaningInput): Promise<Meaning> {
+export function createMeaning(
+  wordbookId: number,
+  wordId: number,
+  input: CreateMeaningInput,
+): Promise<Meaning> {
   return apiRequest({
     method: 'POST',
-    path: '/meanings',
+    path: `/wordbooks/${wordbookId}/words/${wordId}/meanings`,
     body: { meaning: input },
   });
 }
 
 export function updateMeaning(
+  wordbookId: number,
+  wordId: number,
   id: number,
   input: UpdateMeaningInput,
 ): Promise<Meaning> {
   return apiRequest({
     method: 'PATCH',
-    path: `/meanings/${id}`,
+    path: `/wordbooks/${wordbookId}/words/${wordId}/meanings/${id}`,
     body: { meaning: input },
   });
 }
 
-export function deleteMeaning(id: number): Promise<void> {
-  return apiRequest({ method: 'DELETE', path: `/meanings/${id}` });
+export function deleteMeaning(
+  wordbookId: number,
+  wordId: number,
+  id: number,
+): Promise<void> {
+  return apiRequest({
+    method: 'DELETE',
+    path: `/wordbooks/${wordbookId}/words/${wordId}/meanings/${id}`,
+  });
 }

--- a/src/lib/api/settings.ts
+++ b/src/lib/api/settings.ts
@@ -5,33 +5,26 @@ import type {
 } from '@/types/api';
 import { apiRequest } from './client';
 
-export function listSettings(): Promise<Setting[]> {
-  return apiRequest({ method: 'GET', path: '/settings' });
-}
-
-export function getSetting(id: number): Promise<Setting> {
-  return apiRequest({ method: 'GET', path: `/settings/${id}` });
+export function getSetting(): Promise<Setting> {
+  return apiRequest({ method: 'GET', path: '/setting' });
 }
 
 export function createSetting(input: CreateSettingInput): Promise<Setting> {
   return apiRequest({
     method: 'POST',
-    path: '/settings',
+    path: '/setting',
     body: { setting: input },
   });
 }
 
-export function updateSetting(
-  id: number,
-  input: UpdateSettingInput,
-): Promise<Setting> {
+export function updateSetting(input: UpdateSettingInput): Promise<Setting> {
   return apiRequest({
     method: 'PATCH',
-    path: `/settings/${id}`,
+    path: '/setting',
     body: { setting: input },
   });
 }
 
-export function deleteSetting(id: number): Promise<void> {
-  return apiRequest({ method: 'DELETE', path: `/settings/${id}` });
+export function deleteSetting(): Promise<void> {
+  return apiRequest({ method: 'DELETE', path: '/setting' });
 }

--- a/src/lib/api/words.ts
+++ b/src/lib/api/words.ts
@@ -1,33 +1,43 @@
 import type { CreateWordInput, UpdateWordInput, Word } from '@/types/api';
 import { apiRequest } from './client';
 
-export function listWords(): Promise<Word[]> {
-  return apiRequest({ method: 'GET', path: '/words' });
+export function listWords(wordbookId: number): Promise<Word[]> {
+  return apiRequest({ method: 'GET', path: `/wordbooks/${wordbookId}/words` });
 }
 
-export function getWord(id: number): Promise<Word> {
-  return apiRequest({ method: 'GET', path: `/words/${id}` });
+export function getWord(wordbookId: number, id: number): Promise<Word> {
+  return apiRequest({
+    method: 'GET',
+    path: `/wordbooks/${wordbookId}/words/${id}`,
+  });
 }
 
-export function createWord(input: CreateWordInput): Promise<Word> {
+export function createWord(
+  wordbookId: number,
+  input: CreateWordInput,
+): Promise<Word> {
   return apiRequest({
     method: 'POST',
-    path: '/words',
+    path: `/wordbooks/${wordbookId}/words`,
     body: { word: input },
   });
 }
 
 export function updateWord(
+  wordbookId: number,
   id: number,
   input: UpdateWordInput,
 ): Promise<Word> {
   return apiRequest({
     method: 'PATCH',
-    path: `/words/${id}`,
+    path: `/wordbooks/${wordbookId}/words/${id}`,
     body: { word: input },
   });
 }
 
-export function deleteWord(id: number): Promise<void> {
-  return apiRequest({ method: 'DELETE', path: `/words/${id}` });
+export function deleteWord(wordbookId: number, id: number): Promise<void> {
+  return apiRequest({
+    method: 'DELETE',
+    path: `/wordbooks/${wordbookId}/words/${id}`,
+  });
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -74,7 +74,6 @@ export type UpdateWordbookInput = {
 };
 
 export type CreateWordInput = {
-  wordbook_id: number;
   spelling: string;
   status: WordStatus;
   next_review_at?: string | null;
@@ -87,7 +86,6 @@ export type UpdateWordInput = {
 };
 
 export type CreateMeaningInput = {
-  word_id: number;
   content: string;
   display_order: number;
 };
@@ -98,7 +96,6 @@ export type UpdateMeaningInput = {
 };
 
 export type CreateExampleInput = {
-  word_id: number;
   sentence: string;
   translation: string;
   display_order: number;


### PR DESCRIPTION
## Summary
- Update API modules (words, meanings, examples) to use nested URL paths under parent resources (`/wordbooks/{id}/words`, `/wordbooks/{id}/words/{id}/meanings`, etc.)
- Change settings API from plural collection (`/settings/{id}`) to singular resource (`/setting`)
- Remove parent foreign keys (`wordbook_id`, `word_id`) from create input types as they are now part of the URL path
- Update all consumers (server actions, pages, components) to pass parent resource IDs to API functions