### PR TITLE
fix: revalidate test page cache on word mutations and stabilize test session state (#20)

### DIFF
--- a/src/components/test/flashcard-test.tsx
+++ b/src/components/test/flashcard-test.tsx
@@ -20,10 +20,18 @@ type FlashcardTestProps = {
 };
 
 export function FlashcardTest({ words, wordbookId }: FlashcardTestProps) {
+  const [testWords, setTestWords] = useState(words);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [isPending, startTransition] = useTransition();
 
-  if (words.length === 0) {
+  const testWordIds = new Set(testWords.map((w) => w.word.id));
+  const hasNewWords = words.some((w) => !testWordIds.has(w.word.id));
+  if (hasNewWords) {
+    setTestWords(words);
+    setCurrentIndex(0);
+  }
+
+  if (testWords.length === 0) {
     return (
       <div className="text-center py-16">
         <p className="text-lg text-muted-foreground">
@@ -33,13 +41,13 @@ export function FlashcardTest({ words, wordbookId }: FlashcardTestProps) {
     );
   }
 
-  if (currentIndex >= words.length) {
+  if (currentIndex >= testWords.length) {
     return (
-      <TestComplete wordbookId={wordbookId} totalCount={words.length} />
+      <TestComplete wordbookId={wordbookId} totalCount={testWords.length} />
     );
   }
 
-  const current = words[currentIndex];
+  const current = testWords[currentIndex];
 
   function handleEvaluate(evaluation: 'hard' | 'uncertain' | 'easy') {
     startTransition(async () => {
@@ -61,7 +69,7 @@ export function FlashcardTest({ words, wordbookId }: FlashcardTestProps) {
   return (
     <div className="space-y-6">
       <div className="text-center text-sm text-muted-foreground">
-        {currentIndex + 1} / {words.length}
+        {currentIndex + 1} / {testWords.length}
       </div>
 
       <Flashcard

--- a/src/lib/actions/word-actions.ts
+++ b/src/lib/actions/word-actions.ts
@@ -58,6 +58,7 @@ export async function createWordAction(
     }
 
     revalidatePath(`/wordbooks/${wordbookId}`);
+    revalidatePath(`/wordbooks/${wordbookId}/test`);
     redirect(`/wordbooks/${wordbookId}`);
   } catch (error) {
     if (error instanceof ApiError) {
@@ -140,6 +141,7 @@ export async function updateWordAction(
     }
 
     revalidatePath(`/wordbooks/${wordbookId}`);
+    revalidatePath(`/wordbooks/${wordbookId}/test`);
     revalidatePath(`/wordbooks/${wordbookId}/words/${wordId}`);
     redirect(`/wordbooks/${wordbookId}/words/${wordId}`);
   } catch (error) {
@@ -159,6 +161,7 @@ export async function updateWordStatusAction(
   try {
     await updateWord(wordbookId, wordId, { status });
     revalidatePath(`/wordbooks/${wordbookId}`);
+    revalidatePath(`/wordbooks/${wordbookId}/test`);
     revalidatePath(`/wordbooks/${wordbookId}/words/${wordId}`);
     return {};
   } catch (error) {
@@ -177,6 +180,7 @@ export async function deleteWordAction(
   try {
     await deleteWord(wordbookId, wordId);
     revalidatePath(`/wordbooks/${wordbookId}`);
+    revalidatePath(`/wordbooks/${wordbookId}/test`);
     redirect(`/wordbooks/${wordbookId}`);
   } catch (error) {
     if (error instanceof ApiError) {
@@ -242,6 +246,7 @@ export async function evaluateWordAction(
     });
 
     revalidatePath(`/wordbooks/${wordbookId}`);
+    revalidatePath(`/wordbooks/${wordbookId}/test`);
     return {};
   } catch (error) {
     if (error instanceof ApiError) {

--- a/src/lib/actions/word-actions.ts
+++ b/src/lib/actions/word-actions.ts
@@ -246,7 +246,6 @@ export async function evaluateWordAction(
     });
 
     revalidatePath(`/wordbooks/${wordbookId}`);
-    revalidatePath(`/wordbooks/${wordbookId}/test`);
     return {};
   } catch (error) {
     if (error instanceof ApiError) {


### PR DESCRIPTION
## Summary
- Add `revalidatePath` for the test page (`/wordbooks/{id}/test`) in word mutation actions (`create`, `update`, `updateStatus`, `delete`) to fix stale server component cache (#20)
- Remove `revalidatePath` for the test page from `evaluateWordAction` to prevent server re-rendering from desynchronizing client-side test session state
- Snapshot word list in `FlashcardTest` state to isolate active test sessions from mid-test prop changes, with smart reset when genuinely new words are detected
