### PR TITLE
feat: use include param to fetch word with meanings and examples in single request

### DIFF
--- a/src/app/(authenticated)/wordbooks/[wordbookId]/words/[wordId]/edit/page.tsx
+++ b/src/app/(authenticated)/wordbooks/[wordbookId]/words/[wordId]/edit/page.tsx
@@ -6,9 +6,7 @@ import {
 } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { WordForm } from '@/components/word/word-form';
-import { listExamples } from '@/lib/api/examples';
-import { listMeanings } from '@/lib/api/meanings';
-import { getWord } from '@/lib/api/words';
+import { getWordWithDetails } from '@/lib/api/words';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { Suspense } from 'react';
@@ -30,20 +28,15 @@ async function EditWordContent({
 }) {
   let word;
   try {
-    word = await getWord(Number(wordbookId), Number(wordId));
+    word = await getWordWithDetails(Number(wordbookId), Number(wordId));
   } catch {
     notFound();
   }
 
-  const [meanings, examples] = await Promise.all([
-    listMeanings(Number(wordbookId), Number(wordId)),
-    listExamples(Number(wordbookId), Number(wordId)),
-  ]);
-
-  const sortedMeanings = meanings.sort(
+  const sortedMeanings = word.meanings.sort(
     (a, b) => a.display_order - b.display_order,
   );
-  const sortedExamples = examples.sort(
+  const sortedExamples = word.examples.sort(
     (a, b) => a.display_order - b.display_order,
   );
 

--- a/src/app/(authenticated)/wordbooks/[wordbookId]/words/[wordId]/word-detail-content.tsx
+++ b/src/app/(authenticated)/wordbooks/[wordbookId]/words/[wordId]/word-detail-content.tsx
@@ -2,9 +2,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { WordDeleteDialog } from '@/components/word/word-delete-dialog';
 import { WordDetail } from '@/components/word/word-detail';
-import { listExamples } from '@/lib/api/examples';
-import { listMeanings } from '@/lib/api/meanings';
-import { getWord } from '@/lib/api/words';
+import { getWordWithDetails } from '@/lib/api/words';
 import { Edit } from 'lucide-react';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
@@ -20,20 +18,15 @@ export async function WordDetailContent({
 }: WordDetailContentProps) {
   let word;
   try {
-    word = await getWord(Number(wordbookId), Number(wordId));
+    word = await getWordWithDetails(Number(wordbookId), Number(wordId));
   } catch {
     notFound();
   }
 
-  const [meanings, examples] = await Promise.all([
-    listMeanings(Number(wordbookId), Number(wordId)),
-    listExamples(Number(wordbookId), Number(wordId)),
-  ]);
-
-  const sortedMeanings = meanings.sort(
+  const sortedMeanings = word.meanings.sort(
     (a, b) => a.display_order - b.display_order,
   );
-  const sortedExamples = examples.sort(
+  const sortedExamples = word.examples.sort(
     (a, b) => a.display_order - b.display_order,
   );
 

--- a/src/lib/api/words.ts
+++ b/src/lib/api/words.ts
@@ -2,6 +2,7 @@ import type {
   CreateWordInput,
   UpdateWordInput,
   Word,
+  WordWithDetails,
   WordWithFirstMeaning,
 } from '@/types/api';
 import { apiRequest } from './client';
@@ -16,6 +17,16 @@ export function getWord(wordbookId: number, id: number): Promise<Word> {
   return apiRequest({
     method: 'GET',
     path: `/wordbooks/${wordbookId}/words/${id}`,
+  });
+}
+
+export function getWordWithDetails(
+  wordbookId: number,
+  id: number,
+): Promise<WordWithDetails> {
+  return apiRequest({
+    method: 'GET',
+    path: `/wordbooks/${wordbookId}/words/${id}?include=meanings,examples`,
   });
 }
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -49,6 +49,11 @@ export type WordWithFirstMeaning = Word & {
   first_meaning: Meaning | null;
 };
 
+export type WordWithDetails = Word & {
+  meanings: Meaning[];
+  examples: Example[];
+};
+
 export type Example = {
   id: number;
   word_id: number;


### PR DESCRIPTION
## Summary
- Add `WordWithDetails` type and `getWordWithDetails` API function to fetch word with meanings and examples via `?include=meanings,examples` query param
- Replace 3 separate API calls (getWord + listMeanings + listExamples) with a single call in word detail and edit pages