### PR TITLE
feat: use dedicated test endpoint to eliminate N+1 fetch in test page

### DIFF
--- a/src/app/(authenticated)/wordbooks/[wordbookId]/test/page.tsx
+++ b/src/app/(authenticated)/wordbooks/[wordbookId]/test/page.tsx
@@ -1,10 +1,7 @@
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { FlashcardTest } from '@/components/test/flashcard-test';
-import { listExamples } from '@/lib/api/examples';
-import { listMeanings } from '@/lib/api/meanings';
-import { getWordbook } from '@/lib/api/wordbooks';
-import { listWords } from '@/lib/api/words';
+import { getTestWords } from '@/lib/api/words';
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
@@ -19,40 +16,27 @@ export const metadata: Metadata = {
 };
 
 async function TestContent({ wordbookId }: { wordbookId: string }) {
-  let wordbook;
+  let data;
   try {
-    wordbook = await getWordbook(Number(wordbookId));
+    data = await getTestWords(Number(wordbookId));
   } catch {
     notFound();
   }
 
-  const allWords = await listWords(Number(wordbookId));
+  const { wordbook, words } = data;
 
-  const now = new Date();
-  const reviewWords = allWords.filter((w) => {
-    if (w.next_review_at === null) {
-      return true;
-    }
-    return new Date(w.next_review_at) <= now;
+  const wordsWithRelations = words.map((w) => {
+    const { meanings, examples, ...word } = w;
+    return {
+      word,
+      meanings: meanings.sort(
+        (a, b) => a.display_order - b.display_order,
+      ),
+      examples: examples.sort(
+        (a, b) => a.display_order - b.display_order,
+      ),
+    };
   });
-
-  const wordsWithRelations = await Promise.all(
-    reviewWords.map(async (word) => {
-      const [meanings, examples] = await Promise.all([
-        listMeanings(Number(wordbookId), word.id),
-        listExamples(Number(wordbookId), word.id),
-      ]);
-      return {
-        word,
-        meanings: meanings.sort(
-          (a, b) => a.display_order - b.display_order,
-        ),
-        examples: examples.sort(
-          (a, b) => a.display_order - b.display_order,
-        ),
-      };
-    }),
-  );
 
   return (
     <>

--- a/src/lib/api/words.ts
+++ b/src/lib/api/words.ts
@@ -1,5 +1,6 @@
 import type {
   CreateWordInput,
+  TestWordsResponse,
   UpdateWordInput,
   Word,
   WordWithDetails,
@@ -27,6 +28,15 @@ export function getWordWithDetails(
   return apiRequest({
     method: 'GET',
     path: `/wordbooks/${wordbookId}/words/${id}?include=meanings,examples`,
+  });
+}
+
+export function getTestWords(
+  wordbookId: number,
+): Promise<TestWordsResponse> {
+  return apiRequest({
+    method: 'GET',
+    path: `/wordbooks/${wordbookId}/test/words`,
   });
 }
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -54,6 +54,11 @@ export type WordWithDetails = Word & {
   examples: Example[];
 };
 
+export type TestWordsResponse = {
+  wordbook: Wordbook;
+  words: WordWithDetails[];
+};
+
 export type Example = {
   id: number;
   word_id: number;


### PR DESCRIPTION
## Summary
- Replace 2+2N API calls (getWordbook + listWords + N×listMeanings + N×listExamples) with a single `GET /wordbooks/:id/test/words` call on the test page
- Add `TestWordsResponse` type and `getTestWords` API function to support the new dedicated endpoint
- Remove client-side review-eligibility filtering (now handled server-side)