### PR TITLE
fix: nest examples API paths under meanings to match backend spec

### DIFF
--- a/src/lib/actions/word-actions.ts
+++ b/src/lib/actions/word-actions.ts
@@ -5,7 +5,7 @@ import { createWord, deleteWord, updateWord } from '@/lib/api/words';
 import { createMeaning, updateMeaning } from '@/lib/api/meanings';
 import { createExample, updateExample } from '@/lib/api/examples';
 import { getSetting } from '@/lib/api/settings';
-import type { Interval, WordStatus } from '@/types/api';
+import type { Interval, Meaning, WordStatus } from '@/types/api';
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 
@@ -37,20 +37,22 @@ export async function createWordAction(
       status: 'not_studied',
     });
 
+    let createdMeaning: Meaning | undefined;
     if (typeof meaningContent === 'string' && meaningContent.trim() !== '') {
-      await createMeaning(Number(wordbookId), word.id, {
+      createdMeaning = await createMeaning(Number(wordbookId), word.id, {
         content: meaningContent.trim(),
         display_order: 1,
       });
     }
 
     if (
+      createdMeaning !== undefined &&
       typeof exampleSentence === 'string' &&
       exampleSentence.trim() !== '' &&
       typeof exampleTranslation === 'string' &&
       exampleTranslation.trim() !== ''
     ) {
-      await createExample(Number(wordbookId), word.id, {
+      await createExample(Number(wordbookId), word.id, createdMeaning.id, {
         sentence: exampleSentence.trim(),
         translation: exampleTranslation.trim(),
         display_order: 1,
@@ -97,25 +99,36 @@ export async function updateWordAction(
       status: status ?? undefined,
     });
 
+    let effectiveMeaningId: number | undefined =
+      typeof meaningId === 'string' && meaningId !== ''
+        ? Number(meaningId)
+        : undefined;
+
     if (typeof meaningContent === 'string' && meaningContent.trim() !== '') {
-      if (typeof meaningId === 'string' && meaningId !== '') {
+      if (effectiveMeaningId !== undefined) {
         await updateMeaning(
           Number(wordbookId),
           Number(wordId),
-          Number(meaningId),
+          effectiveMeaningId,
           {
             content: meaningContent.trim(),
           },
         );
       } else {
-        await createMeaning(Number(wordbookId), Number(wordId), {
-          content: meaningContent.trim(),
-          display_order: 1,
-        });
+        const createdMeaning = await createMeaning(
+          Number(wordbookId),
+          Number(wordId),
+          {
+            content: meaningContent.trim(),
+            display_order: 1,
+          },
+        );
+        effectiveMeaningId = createdMeaning.id;
       }
     }
 
     if (
+      effectiveMeaningId !== undefined &&
       typeof exampleSentence === 'string' &&
       exampleSentence.trim() !== '' &&
       typeof exampleTranslation === 'string' &&
@@ -125,6 +138,7 @@ export async function updateWordAction(
         await updateExample(
           Number(wordbookId),
           Number(wordId),
+          effectiveMeaningId,
           Number(exampleId),
           {
             sentence: exampleSentence.trim(),
@@ -132,11 +146,16 @@ export async function updateWordAction(
           },
         );
       } else {
-        await createExample(Number(wordbookId), Number(wordId), {
-          sentence: exampleSentence.trim(),
-          translation: exampleTranslation.trim(),
-          display_order: 1,
-        });
+        await createExample(
+          Number(wordbookId),
+          Number(wordId),
+          effectiveMeaningId,
+          {
+            sentence: exampleSentence.trim(),
+            translation: exampleTranslation.trim(),
+            display_order: 1,
+          },
+        );
       }
     }
 

--- a/src/lib/api/examples.ts
+++ b/src/lib/api/examples.ts
@@ -8,32 +8,35 @@ import { apiRequest } from './client';
 export function listExamples(
   wordbookId: number,
   wordId: number,
+  meaningId: number,
 ): Promise<Example[]> {
   return apiRequest({
     method: 'GET',
-    path: `/wordbooks/${wordbookId}/words/${wordId}/examples`,
+    path: `/wordbooks/${wordbookId}/words/${wordId}/meanings/${meaningId}/examples`,
   });
 }
 
 export function getExample(
   wordbookId: number,
   wordId: number,
+  meaningId: number,
   id: number,
 ): Promise<Example> {
   return apiRequest({
     method: 'GET',
-    path: `/wordbooks/${wordbookId}/words/${wordId}/examples/${id}`,
+    path: `/wordbooks/${wordbookId}/words/${wordId}/meanings/${meaningId}/examples/${id}`,
   });
 }
 
 export function createExample(
   wordbookId: number,
   wordId: number,
+  meaningId: number,
   input: CreateExampleInput,
 ): Promise<Example> {
   return apiRequest({
     method: 'POST',
-    path: `/wordbooks/${wordbookId}/words/${wordId}/examples`,
+    path: `/wordbooks/${wordbookId}/words/${wordId}/meanings/${meaningId}/examples`,
     body: { example: input },
   });
 }
@@ -41,12 +44,13 @@ export function createExample(
 export function updateExample(
   wordbookId: number,
   wordId: number,
+  meaningId: number,
   id: number,
   input: UpdateExampleInput,
 ): Promise<Example> {
   return apiRequest({
     method: 'PATCH',
-    path: `/wordbooks/${wordbookId}/words/${wordId}/examples/${id}`,
+    path: `/wordbooks/${wordbookId}/words/${wordId}/meanings/${meaningId}/examples/${id}`,
     body: { example: input },
   });
 }
@@ -54,10 +58,11 @@ export function updateExample(
 export function deleteExample(
   wordbookId: number,
   wordId: number,
+  meaningId: number,
   id: number,
 ): Promise<void> {
   return apiRequest({
     method: 'DELETE',
-    path: `/wordbooks/${wordbookId}/words/${wordId}/examples/${id}`,
+    path: `/wordbooks/${wordbookId}/words/${wordId}/meanings/${meaningId}/examples/${id}`,
   });
 }


### PR DESCRIPTION
## Summary

- Addresses **Critical #1** in `docs/api-frontend-mismatches.md`.
- Per the OpenAPI spec, the Examples endpoints are nested under Meaning, but the frontend was hitting paths without `meaning_id`, causing every Examples CRUD call to 404.
- Added `meaningId` to all 5 functions in `src/lib/api/examples.ts` and updated their URLs to `/meanings/{meaning_id}/examples...`.
- In `createWordAction` / `updateWordAction`, capture the meaning id returned by `createMeaning` and pass it through to `createExample` / `updateExample`. Cases where examples are submitted without any meaning are skipped, since the API spec makes that combination impossible.

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm build` passes