### PR TITLE
docs: align openapi spec with backend and catalog frontend mismatches

### DIFF
--- a/docs/api-frontend-mismatches.md
+++ b/docs/api-frontend-mismatches.md
@@ -1,0 +1,205 @@
+# フロントエンド ↔ バックエンド API 仕様の差分一覧
+
+`docs/openapi.yaml` を正として、フロントエンド側がまだ追従できていない箇所をまとめる。
+カテゴリ別に「Critical(動作不能)」「High(レスポンス読み違い)」「Medium(型定義の余剰/最適化漏れ)」で分類した。
+
+---
+
+## Critical — このままでは動かない
+
+### 1. Examples エンドポイントのパスが Meaning ネストになっていない
+
+OpenAPI:
+
+```
+/api/v1/wordbooks/{wordbook_id}/words/{word_id}/meanings/{meaning_id}/examples
+/api/v1/wordbooks/{wordbook_id}/words/{word_id}/meanings/{meaning_id}/examples/{id}
+```
+
+フロント実装(`src/lib/api/examples.ts`):
+
+```
+/wordbooks/${wordbookId}/words/${wordId}/examples
+/wordbooks/${wordbookId}/words/${wordId}/examples/${id}
+```
+
+→ `meaning_id` がパスに含まれていないため、Examples の CRUD が全て 404。
+- `src/lib/api/examples.ts:8-63` の全関数シグネチャに `meaningId` を追加
+- 呼び出し側 `src/lib/actions/word-actions.ts:23,52,82,123,134` も `meaningId` を渡すよう修正
+
+---
+
+### 2. `Meaning` のフィールド名 `content` → `definition`
+
+OpenAPI `Meaning.definition` (`openapi.yaml:1052`)。フロントは `content` 前提。
+
+影響箇所:
+- `src/types/api.ts:42` — 型定義 `content: string`
+- `src/types/api.ts:101,106` — `Create/UpdateMeaningInput.content`
+- `src/lib/actions/word-actions.ts:41,106,111` — リクエストボディに `content` を送信
+- `src/components/word/word-detail.tsx:29` — `meaning.content` 表示
+- `src/components/word/word-card.tsx:21` — `meaning.content` 表示
+- `src/components/test/flashcard.tsx:43` — `meaning.content` 表示
+- `src/components/word/word-list.tsx:28` — `first_meaning.content` 検索
+
+→ 送信時/表示時とも全滅。`definition` に統一。
+
+---
+
+### 3. `WordWithRelations` / `TestWordsResponse` の examples が meaning にネストされる
+
+OpenAPI:
+
+```yaml
+WordWithRelations:
+  meanings:
+    - definition, display_order
+      examples: [ ... ]   # meaning にネスト
+```
+
+フロント `src/types/api.ts:52-55`:
+
+```ts
+export type WordWithDetails = Word & {
+  meanings: Meaning[];
+  examples: Example[];   # word 直下に flat
+};
+```
+
+影響箇所:
+- `src/types/api.ts:52-60` — `WordWithDetails` / `TestWordsResponse.words` の型
+- `src/app/(authenticated)/wordbooks/[wordbookId]/test/page.tsx:28-39` — `{ meanings, examples, ...word }` 分解
+- `src/app/(authenticated)/wordbooks/[wordbookId]/words/[wordId]/word-detail-content.tsx:29-31,59` — `word.examples.sort(...)`
+- `src/app/(authenticated)/wordbooks/[wordbookId]/words/[wordId]/edit/page.tsx:39` — `word.examples.sort(...)`
+- `src/components/word/word-detail.tsx:9,12,36,44` — `examples` を独立 prop で受け取り
+- `src/components/test/flashcard.tsx:11,14,48,50` — 同上
+- `src/components/test/flashcard-test.tsx:14,79` — `examples` を独立 prop で渡す
+
+→ Test 画面・単語詳細画面ともに examples が空配列扱いになり表示されない。
+meaning ごとに examples を表示する UI に組み替える必要あり。
+
+---
+
+## High — レスポンスが読めず実行時エラー
+
+### 4. List エンドポイントの `{ data, pagination }` エンベロープ未対応
+
+OpenAPI 全 list 系(wordbooks / words / meanings / examples)は次の形:
+
+```json
+{ "data": [...], "pagination": { current_page, total_pages, total_count, per_page } }
+```
+
+フロント実装は配列をそのまま受け取る前提:
+- `src/lib/api/wordbooks.ts:8` — `listWordbooks(): Promise<Wordbook[]>`
+- `src/lib/api/words.ts:11-15` — `listWords(): Promise<WordWithFirstMeaning[]>`
+- `src/lib/api/meanings.ts:8-16` — `listMeanings(): Promise<Meaning[]>`
+- `src/lib/api/examples.ts:8-16` — `listExamples(): Promise<Example[]>`
+
+呼び出し側:
+- `src/components/wordbook/wordbook-list.tsx:5` — `wordbooks.map(...)` でクラッシュ
+- `src/components/word/word-list.tsx:12` — `allWords.filter(...)` でクラッシュ
+
+→ 戻り値型を `{ data, pagination }` に変更 + `page` / `per_page` クエリパラメータをサポート。
+
+---
+
+### 5. `WordWithFirstMeaning.first_meaning` の shape
+
+OpenAPI(`openapi.yaml:1002-1008`):
+
+```yaml
+first_meaning:
+  type: object
+  properties:
+    definition: { type: string }
+```
+
+→ `definition` のみを持つ薄い object。
+
+フロント `src/types/api.ts:48-50`:
+
+```ts
+export type WordWithFirstMeaning = Word & {
+  first_meaning: Meaning | null;   # フル Meaning と仮定
+};
+```
+
+→ `id` / `display_order` などにアクセスすると undefined。
+
+---
+
+### 6. `CreateWordInput.status` を送っているが OpenAPI POST では受け付けない
+
+OpenAPI POST `/wordbooks/{id}/words`(`openapi.yaml:286-321`):
+
+```yaml
+required: [spelling]
+properties: { spelling, meanings_attributes }
+```
+
+`status` の指定不可。
+
+フロント:
+- `src/types/api.ts:90-93` — `CreateWordInput { spelling, status }` を必須化
+- `src/lib/actions/word-actions.ts:34-37` — `status: 'not_studied'` を送信
+
+→ 422 にはならないかもしれないが、契約上は不要なので除去。
+
+---
+
+## Medium — 型定義の余剰 / 最適化漏れ
+
+### 7. Word の作成で nested attributes を活用していない(N+1 リクエスト)
+
+OpenAPI POST `/words` は `meanings_attributes` + ネストした `examples_attributes` を 1 トランザクションで受け付ける。
+
+`src/lib/actions/word-actions.ts:33-57` は word → meaning → example を逐次 3 リクエスト発行。
+
+→ 1 リクエストにまとめると、原子性が担保され、ネットワーク往復も削減できる。
+
+---
+
+### 8. ドメインモデルに OpenAPI 非公開のフィールドが残っている
+
+| 型 | フロントの余剰フィールド | 出典 |
+|---|---|---|
+| `Wordbook` | `user_id`, `updated_at` | `src/types/api.ts:21-27` |
+| `Word` | `wordbook_id`, `created_at`, `updated_at` | `src/types/api.ts:29-37` |
+| `Meaning` | `word_id`, `created_at`, `updated_at` | `src/types/api.ts:39-46` |
+| `Example` | `word_id`, `created_at`, `updated_at` | `src/types/api.ts:62-70` |
+| `Setting` | `id`, `user_id`, `created_at`, `updated_at` | `src/types/api.ts:72-80` |
+| `User` | `id`, `provider`, `provider_uid`, `created_at`, `updated_at` | `src/types/api.ts:9-19` |
+
+→ 受信時は単に無視されるだけだが、参照しているコードがあると `undefined`。
+`Example.word_id` は本来 `meaning_id` 相当だが、OpenAPI では公開していないので削除推奨。
+
+---
+
+### 9. Auth レスポンス型未定義
+
+OpenAPI `/api/v1/auth/guest`, `/api/v1/auth/google` は次を返す:
+
+```
+{ user: { email?, name?, avatar_url?, guest_expires_at? }, token: string }
+```
+
+フロント側に対応する型が存在しない(`src/types/dto.ts` には `GuestUserDTO { name, token }` のみ)。
+NextAuth 側で必要な値だけパースしているので即時バグにはならないが、型整備の余地あり。
+
+---
+
+### 10. Test エンドポイント `wordbook` レスポンスの型整合
+
+OpenAPI(`openapi.yaml:1024-1030`)では `wordbook` は `{ id, title }` のみ。
+フロント `TestWordsResponse.wordbook: Wordbook` は `user_id` / `created_at` / `updated_at` を含む型。
+→ 上記 #8 と同根。`Pick<Wordbook, 'id' | 'title'>` 程度に絞るのが正しい。
+
+---
+
+## 対応の優先順位(推奨)
+
+1. **Critical 3 件** を 1 PR で対応(Examples パス・`definition` リネーム・examples ネスト対応)
+2. **High 3 件** を 1 PR(`{ data, pagination }` エンベロープ・`first_meaning` shape・`status` 送信除去)
+3. **Medium** は型クリーンアップとして個別 PR
+   - 特に #7(nested attributes 活用)はすでに `feat/use-include-param` 系の最適化方針と整合的

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -113,15 +113,23 @@ paths:
       summary: List current user's wordbooks
       security:
         - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/Page"
+        - $ref: "#/components/parameters/PerPage"
       responses:
         "200":
           description: OK
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Wordbook"
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Wordbook"
+                  pagination:
+                    $ref: "#/components/schemas/Pagination"
         "401":
           $ref: "#/components/responses/Unauthorized"
     post:
@@ -237,25 +245,38 @@ paths:
     get:
       tags: [Words]
       summary: List words in a wordbook
-      description: Returns all words with their first meaning (by display_order) included.
+      description: Returns words with their first meaning (by display_order) included.
       security:
         - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/Page"
+        - $ref: "#/components/parameters/PerPage"
       responses:
         "200":
           description: OK
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/WordWithFirstMeaning"
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/WordWithFirstMeaning"
+                  pagination:
+                    $ref: "#/components/schemas/Pagination"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
     post:
       tags: [Words]
-      summary: Create a word in a wordbook
+      summary: Create a word with optional nested meanings and examples
+      description: |
+        Creates a word in the wordbook. Optionally accepts nested `meanings_attributes`
+        (with `examples_attributes` inside each meaning) to create related records in a
+        single atomic transaction. The response always includes `meanings` array with
+        nested `examples`.
       security:
         - bearerAuth: []
       requestBody:
@@ -268,23 +289,43 @@ paths:
               properties:
                 word:
                   type: object
-                  required: [spelling, status]
+                  required: [spelling]
                   properties:
                     spelling:
                       type: string
-                    status:
-                      $ref: "#/components/schemas/WordStatus"
-                    next_review_at:
-                      type: string
-                      format: date-time
-                      nullable: true
+                    meanings_attributes:
+                      type: array
+                      description: Optional nested meanings to create with the word
+                      items:
+                        type: object
+                        required: [definition, display_order]
+                        properties:
+                          definition:
+                            type: string
+                          display_order:
+                            type: integer
+                            minimum: 1
+                          examples_attributes:
+                            type: array
+                            description: Optional nested examples to create with the meaning
+                            items:
+                              type: object
+                              required: [sentence, translation, display_order]
+                              properties:
+                                sentence:
+                                  type: string
+                                translation:
+                                  type: string
+                                display_order:
+                                  type: integer
+                                  minimum: 1
       responses:
         "201":
           description: Created
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Word"
+                $ref: "#/components/schemas/WordWithRelations"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -314,7 +355,9 @@ paths:
         - name: include
           in: query
           required: false
-          description: Comma-separated list of relations to include. Allowed values: meanings, examples.
+          description: |
+            Comma-separated list of relations to include. Allowed values: meanings, examples.
+            When examples is specified, meanings are automatically included with nested examples.
           schema:
             type: string
             example: meanings,examples
@@ -349,10 +392,6 @@ paths:
                       type: string
                     status:
                       $ref: "#/components/schemas/WordStatus"
-                    next_review_at:
-                      type: string
-                      format: date-time
-                      nullable: true
       responses:
         "200":
           description: Updated
@@ -419,15 +458,23 @@ paths:
       summary: List meanings for a word
       security:
         - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/Page"
+        - $ref: "#/components/parameters/PerPage"
       responses:
         "200":
           description: OK
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Meaning"
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Meaning"
+                  pagination:
+                    $ref: "#/components/schemas/Pagination"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "404":
@@ -447,9 +494,9 @@ paths:
               properties:
                 meaning:
                   type: object
-                  required: [content, display_order]
+                  required: [definition, display_order]
                   properties:
-                    content:
+                    definition:
                       type: string
                     display_order:
                       type: integer
@@ -511,7 +558,7 @@ paths:
                 meaning:
                   type: object
                   properties:
-                    content:
+                    definition:
                       type: string
                     display_order:
                       type: integer
@@ -549,31 +596,40 @@ paths:
           $ref: "#/components/responses/NotFound"
 
   # ──────────────── Examples ────────────────
-  /api/v1/wordbooks/{wordbook_id}/words/{word_id}/examples:
+  /api/v1/wordbooks/{wordbook_id}/words/{word_id}/meanings/{meaning_id}/examples:
     parameters:
       - $ref: "#/components/parameters/WordbookId"
       - $ref: "#/components/parameters/WordId"
+      - $ref: "#/components/parameters/MeaningId"
     get:
       tags: [Examples]
-      summary: List examples for a word
+      summary: List examples for a meaning
       security:
         - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/Page"
+        - $ref: "#/components/parameters/PerPage"
       responses:
         "200":
           description: OK
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Example"
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Example"
+                  pagination:
+                    $ref: "#/components/schemas/Pagination"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
     post:
       tags: [Examples]
-      summary: Create an example for a word
+      summary: Create an example for a meaning
       security:
         - bearerAuth: []
       requestBody:
@@ -615,10 +671,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/ValidationErrors"
 
-  /api/v1/wordbooks/{wordbook_id}/words/{word_id}/examples/{id}:
+  /api/v1/wordbooks/{wordbook_id}/words/{word_id}/meanings/{meaning_id}/examples/{id}:
     parameters:
       - $ref: "#/components/parameters/WordbookId"
       - $ref: "#/components/parameters/WordId"
+      - $ref: "#/components/parameters/MeaningId"
       - $ref: "#/components/parameters/Id"
     get:
       tags: [Examples]
@@ -803,6 +860,24 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  # ──────────────── User (singular resource) ────────────────
+  /api/v1/user:
+    delete:
+      tags: [Users]
+      summary: Delete the current user account
+      description: |
+        Permanently deletes the authenticated user and all associated data
+        (wordbooks, words, meanings, examples, settings) via cascading deletes.
+        The JWT token is not revoked server-side, but subsequent requests with
+        the orphaned token will return 401.
+      security:
+        - bearerAuth: []
+      responses:
+        "204":
+          description: No Content
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
 components:
   securitySchemes:
     googleIdToken:
@@ -834,6 +909,31 @@ components:
       required: true
       schema:
         type: integer
+    MeaningId:
+      name: meaning_id
+      in: path
+      required: true
+      schema:
+        type: integer
+    Page:
+      name: page
+      in: query
+      required: false
+      description: Page number (default 1)
+      schema:
+        type: integer
+        minimum: 1
+        default: 1
+    PerPage:
+      name: per_page
+      in: query
+      required: false
+      description: Number of items per page (default 20, max 100)
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+        default: 20
 
   responses:
     Unauthorized:
@@ -869,51 +969,14 @@ components:
 
   schemas:
     # ──── Models ────
-    User:
-      type: object
-      properties:
-        id:
-          type: integer
-        provider:
-          type: string
-          enum: [google, guest]
-        provider_uid:
-          type: string
-          nullable: true
-        email:
-          type: string
-          nullable: true
-        name:
-          type: string
-          nullable: true
-        avatar_url:
-          type: string
-          nullable: true
-        guest_expires_at:
-          type: string
-          format: date-time
-          nullable: true
-          description: Present only for guest users (expires 7 days after creation)
-        created_at:
-          type: string
-          format: date-time
-        updated_at:
-          type: string
-          format: date-time
-
     Wordbook:
       type: object
       properties:
         id:
           type: integer
-        user_id:
-          type: integer
         title:
           type: string
         created_at:
-          type: string
-          format: date-time
-        updated_at:
           type: string
           format: date-time
 
@@ -921,8 +984,6 @@ components:
       type: object
       properties:
         id:
-          type: integer
-        wordbook_id:
           type: integer
         spelling:
           type: string
@@ -932,12 +993,6 @@ components:
           type: string
           format: date-time
           nullable: true
-        created_at:
-          type: string
-          format: date-time
-        updated_at:
-          type: string
-          format: date-time
 
     WordWithFirstMeaning:
       allOf:
@@ -947,8 +1002,10 @@ components:
             first_meaning:
               nullable: true
               description: The meaning with the lowest display_order, or null if no meanings exist
-              allOf:
-                - $ref: "#/components/schemas/Meaning"
+              type: object
+              properties:
+                definition:
+                  type: string
 
     WordWithRelations:
       allOf:
@@ -957,14 +1014,9 @@ components:
           properties:
             meanings:
               type: array
-              description: Present only when include=meanings is specified
+              description: Present when include=meanings or include=examples is specified
               items:
-                $ref: "#/components/schemas/Meaning"
-            examples:
-              type: array
-              description: Present only when include=examples is specified
-              items:
-                $ref: "#/components/schemas/Example"
+                $ref: "#/components/schemas/MeaningWithExamples"
 
     TestWordsResponse:
       type: object
@@ -986,11 +1038,7 @@ components:
                   meanings:
                     type: array
                     items:
-                      $ref: "#/components/schemas/Meaning"
-                  examples:
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/Example"
+                      $ref: "#/components/schemas/MeaningWithExamples"
 
     WordStatus:
       type: string
@@ -1001,26 +1049,27 @@ components:
       properties:
         id:
           type: integer
-        word_id:
-          type: integer
-        content:
+        definition:
           type: string
         display_order:
           type: integer
           minimum: 1
-        created_at:
-          type: string
-          format: date-time
-        updated_at:
-          type: string
-          format: date-time
+
+    MeaningWithExamples:
+      allOf:
+        - $ref: "#/components/schemas/Meaning"
+        - type: object
+          properties:
+            examples:
+              type: array
+              description: Present when include=examples is specified
+              items:
+                $ref: "#/components/schemas/Example"
 
     Example:
       type: object
       properties:
         id:
-          type: integer
-        word_id:
           type: integer
         sentence:
           type: string
@@ -1029,12 +1078,6 @@ components:
         display_order:
           type: integer
           minimum: 1
-        created_at:
-          type: string
-          format: date-time
-        updated_at:
-          type: string
-          format: date-time
 
     Setting:
       type: object
@@ -1042,22 +1085,12 @@ components:
         Interval fields are returned as {days, hours, minutes} objects
         (converted from PostgreSQL interval internally).
       properties:
-        id:
-          type: integer
-        user_id:
-          type: integer
         hard_interval:
           $ref: "#/components/schemas/IntervalOutput"
         uncertain_interval:
           $ref: "#/components/schemas/IntervalOutput"
         easy_interval:
           $ref: "#/components/schemas/IntervalOutput"
-        created_at:
-          type: string
-          format: date-time
-        updated_at:
-          type: string
-          format: date-time
 
     IntervalInput:
       type: object
@@ -1082,6 +1115,18 @@ components:
         hours:
           type: integer
         minutes:
+          type: integer
+
+    Pagination:
+      type: object
+      properties:
+        current_page:
+          type: integer
+        total_pages:
+          type: integer
+        total_count:
+          type: integer
+        per_page:
           type: integer
 
     # ──── Error responses ────


### PR DESCRIPTION
## Summary

Documentation-only update to bring `docs/openapi.yaml` in line with the actual backend behavior and to catalog where the frontend has drifted from that spec. No runtime code changes.

### `docs/openapi.yaml`

- Pagination envelopes: list endpoints (`wordbooks`, `words`, `meanings`, `examples`) now return `{ data, pagination }` and accept `page` / `per_page` query params.
- Examples are nested under meanings: paths moved to `/wordbooks/{wordbook_id}/words/{word_id}/meanings/{meaning_id}/examples`.
- Word create accepts nested `meanings_attributes` (with `examples_attributes`) for atomic creation; response uses `WordWithRelations`.
- `Meaning.content` renamed to `definition`; `WordWithFirstMeaning.first_meaning` reduced to `{ definition }`.
- `WordWithRelations` and `TestWordsResponse` now expose `examples` nested inside each `meaning` (no more flat top-level `examples`).
- Trimmed audit fields (`created_at`/`updated_at`/`user_id` etc.) from responses to match what the backend actually returns.
- Added `DELETE /api/v1/user` for account deletion.
- New `Pagination` schema and shared `Page` / `PerPage` / `MeaningId` parameters.

### `docs/api-frontend-mismatches.md` (new)

Categorized analysis of where the frontend lags the corrected spec, ordered Critical → High → Medium with specific file/line references and a suggested PR breakdown:

- Critical: examples path missing `meaning_id`, `content` → `definition`, examples-nested-in-meanings response shape.
- High: pagination envelope handling, `first_meaning` shape, `status` field on word create.
- Medium: nested `meanings_attributes` optimization, surplus model fields, auth response typing, test endpoint `wordbook` shape.

## Test plan

- [x] `docs/openapi.yaml` lints cleanly (Swagger/OpenAPI viewer of choice)
- [x] `docs/api-frontend-mismatches.md` renders correctly on GitHub
- [x] No source under `src/` was modified (verify via `git diff main -- src/`)
