### PR TITLE
fix: remove hardcoded status from word creation request

### DIFF
--- a/src/lib/actions/word-actions.ts
+++ b/src/lib/actions/word-actions.ts
@@ -34,7 +34,6 @@ export async function createWordAction(
   try {
     const word = await createWord(Number(wordbookId), {
       spelling: spelling.trim(),
-      status: 'not_studied',
     });
 
     if (typeof meaningContent === 'string' && meaningContent.trim() !== '') {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -89,7 +89,7 @@ export type UpdateWordbookInput = {
 
 export type CreateWordInput = {
   spelling: string;
-  status: WordStatus;
+  status?: WordStatus;
   next_review_at?: string | null;
 };
 


### PR DESCRIPTION
Make `status` optional in `CreateWordInput` and drop the hardcoded `'not_studied'` value from `createWordAction`. Default status assignment is now the backend's responsibility.

Closes #28

Generated with [Claude Code](https://claude.ai/code)