### PR TITLE
fix: rename Meaning.content to Meaning.definition to match API

### DIFF
--- a/src/components/test/flashcard.tsx
+++ b/src/components/test/flashcard.tsx
@@ -40,7 +40,7 @@ export function Flashcard({ word, meanings, examples }: FlashcardProps) {
                 <div className="space-y-1">
                   {meanings.map((meaning) => (
                     <p key={meaning.id} className="text-2xl font-bold">
-                      {meaning.content}
+                      {meaning.definition}
                     </p>
                   ))}
                 </div>

--- a/src/components/word/word-card.tsx
+++ b/src/components/word/word-card.tsx
@@ -18,7 +18,7 @@ export function WordCard({ word, meaning, wordbookId }: WordCardProps) {
             <span className="font-semibold text-lg">{word.spelling}</span>
             {meaning !== undefined && (
               <span className="text-muted-foreground text-sm truncate">
-                {meaning.content}
+                {meaning.definition}
               </span>
             )}
           </div>

--- a/src/components/word/word-detail.tsx
+++ b/src/components/word/word-detail.tsx
@@ -26,7 +26,7 @@ export function WordDetail({ word, meanings, examples }: WordDetailProps) {
           <ul className="space-y-1">
             {meanings.map((meaning) => (
               <li key={meaning.id} className="text-lg">
-                {meaning.content}
+                {meaning.definition}
               </li>
             ))}
           </ul>

--- a/src/components/word/word-form.tsx
+++ b/src/components/word/word-form.tsx
@@ -63,7 +63,7 @@ export function WordForm({ wordbookId, word, meaning, example }: WordFormProps) 
         <Input
           id="meaning"
           name="meaning"
-          defaultValue={meaning?.content ?? ''}
+          defaultValue={meaning?.definition ?? ''}
           placeholder="例: りんご"
         />
       </div>

--- a/src/components/word/word-list.tsx
+++ b/src/components/word/word-list.tsx
@@ -25,7 +25,7 @@ export async function WordList({ wordbookId, status, query }: WordListProps) {
       }
       if (
         w.first_meaning !== null &&
-        w.first_meaning.content.toLowerCase().includes(lowerQuery)
+        w.first_meaning.definition.toLowerCase().includes(lowerQuery)
       ) {
         return true;
       }

--- a/src/lib/actions/word-actions.ts
+++ b/src/lib/actions/word-actions.ts
@@ -38,7 +38,7 @@ export async function createWordAction(
 
     if (typeof meaningContent === 'string' && meaningContent.trim() !== '') {
       await createMeaning(Number(wordbookId), word.id, {
-        content: meaningContent.trim(),
+        definition: meaningContent.trim(),
         display_order: 1,
       });
     }
@@ -103,12 +103,12 @@ export async function updateWordAction(
           Number(wordId),
           Number(meaningId),
           {
-            content: meaningContent.trim(),
+            definition: meaningContent.trim(),
           },
         );
       } else {
         await createMeaning(Number(wordbookId), Number(wordId), {
-          content: meaningContent.trim(),
+          definition: meaningContent.trim(),
           display_order: 1,
         });
       }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -39,7 +39,7 @@ export type Word = {
 export type Meaning = {
   id: number;
   word_id: number;
-  content: string;
+  definition: string;
   display_order: number;
   created_at: string;
   updated_at: string;
@@ -100,12 +100,12 @@ export type UpdateWordInput = {
 };
 
 export type CreateMeaningInput = {
-  content: string;
+  definition: string;
   display_order: number;
 };
 
 export type UpdateMeaningInput = {
-  content?: string;
+  definition?: string;
   display_order?: number;
 };
 


### PR DESCRIPTION
Renames the `content` field to `definition` on the `Meaning` type everywhere in the frontend, aligning with the OpenAPI contract. Fixes #31.

Generated with [Claude Code](https://claude.ai/code)