### PR TITLE
feat: add AuthUser and AuthResponse types for auth endpoint payloads

### DIFF
--- a/src/data/guest-user.ts
+++ b/src/data/guest-user.ts
@@ -1,13 +1,6 @@
 import 'server-only';
 
-import type { GuestUserDTO } from '@/types/dto';
-
-type GuestAuthResponse = {
-  user: {
-    guest_expires_at: string;
-  };
-  token: string;
-};
+import type { AuthResponse, GuestUserDTO } from '@/types/dto';
 
 export async function createGuestUser(): Promise<GuestUserDTO> {
   if (process.env.API_URL === undefined) {
@@ -22,7 +15,7 @@ export async function createGuestUser(): Promise<GuestUserDTO> {
     throw new Error(`Guest auth failed: ${response.status}`);
   }
 
-  const result = (await response.json()) as GuestAuthResponse;
+  const result = (await response.json()) as AuthResponse;
 
   return {
     name: 'ゲスト',

--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -2,6 +2,7 @@ import NextAuth from 'next-auth';
 import type { Provider } from 'next-auth/providers';
 import Credentials from 'next-auth/providers/credentials';
 import { createGuestUser } from '@/data/guest-user';
+import type { AuthResponse } from '@/types/dto';
 import { getAndClearGuestTokenCookie } from './guest-migration';
 import { getAuthJsProviders } from './providers';
 
@@ -78,9 +79,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
             throw new Error(`Authentication failed: ${response.status}`);
           }
 
-          const result = (await response.json()) as {
-            token: string;
-          };
+          const result = (await response.json()) as AuthResponse;
           token.accessToken = result.token;
           token.isGuest = false;
         } catch (error) {

--- a/src/types/dto.ts
+++ b/src/types/dto.ts
@@ -2,3 +2,15 @@ export type GuestUserDTO = {
   name: string;
   token: string;
 };
+
+export type AuthUser = {
+  email: string;
+  name: string;
+  avatar_url: string;
+  guest_expires_at: string | null;
+};
+
+export type AuthResponse = {
+  user: AuthUser;
+  token: string;
+};


### PR DESCRIPTION
Introduces shared `AuthUser` and `AuthResponse` types in `src/types/dto.ts` matching the OpenAPI contract for `/auth/guest` and `/auth/google`. Replaces the local `GuestAuthResponse` type in `src/data/guest-user.ts` and the inline `{ token: string }` cast in the NextAuth Google callback.

Closes #37

Generated with [Claude Code](https://claude.ai/code)