### PR TITLE
docs: add communication guideline to respond in Japanese

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,3 +121,8 @@ Required in `.env.local`:
 - During implementation, commit incrementally according to the plan. Create each commit as soon as the corresponding unit of work is complete, rather than batching all commits at the end.
 - When committing, follow the rules defined in `.claude/skills/git-commit/SKILL.md`.
 - After the final commit, immediately push the branch and create a PR following the rules in `.claude/skills/pull-request/SKILL.md`. Do not stop or wait for user input between the last commit and PR creation.
+
+
+## Communication
+
+- Respond in Japanese


### PR DESCRIPTION
## Summary

- Add a Communication section to `CLAUDE.md` instructing Claude Code to respond in Japanese.

## Test plan

- [x] Verified the new section renders correctly in `CLAUDE.md`.
