### PR TITLE
chore: drop non-OpenAPI fields from domain model types

### DIFF
--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -7,42 +7,29 @@ export type Interval = {
 };
 
 export type User = {
-  id: number;
-  provider: 'google' | 'guest';
-  provider_uid: string;
   email: string | null;
   name: string | null;
   avatar_url: string | null;
   guest_expires_at: string | null;
-  created_at: string;
-  updated_at: string;
 };
 
 export type Wordbook = {
   id: number;
-  user_id: number;
   title: string;
   created_at: string;
-  updated_at: string;
 };
 
 export type Word = {
   id: number;
-  wordbook_id: number;
   spelling: string;
   status: WordStatus;
   next_review_at: string | null;
-  created_at: string;
-  updated_at: string;
 };
 
 export type Meaning = {
   id: number;
-  word_id: number;
   definition: string;
   display_order: number;
-  created_at: string;
-  updated_at: string;
 };
 
 export type WordWithFirstMeaning = Word & {
@@ -61,22 +48,15 @@ export type TestWordsResponse = {
 
 export type Example = {
   id: number;
-  word_id: number;
   sentence: string;
   translation: string;
   display_order: number;
-  created_at: string;
-  updated_at: string;
 };
 
 export type Setting = {
-  id: number;
-  user_id: number;
   hard_interval: Interval | null;
   uncertain_interval: Interval | null;
   easy_interval: Interval | null;
-  created_at: string;
-  updated_at: string;
 };
 
 export type CreateWordbookInput = {


### PR DESCRIPTION
## Summary
- Remove fields absent from the OpenAPI contract (`id`, `user_id`, `provider`, `provider_uid`, `wordbook_id`, `word_id`, `created_at`, `updated_at` as applicable) from `User`, `Wordbook`, `Word`, `Meaning`, `Example`, and `Setting` in `src/types/api.ts`.
- These fields were silently `undefined` at runtime since the API never returned them. No callers read the removed fields, so this is a type-only cleanup.

Closes #36