### PR TITLE
fix: validate zero-duration SRS intervals on the client

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "react-icons": "^5.5.0",
     "server-only": "^0.0.1",
     "sonner": "^2.0.7",
-    "tailwind-merge": "^3.4.0"
+    "tailwind-merge": "^3.4.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.2
@@ -3055,8 +3058,8 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  zod@4.1.13:
-    resolution: {integrity: sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==}
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
 
@@ -4963,8 +4966,8 @@ snapshots:
       '@babel/parser': 7.28.5
       eslint: 9.39.1(jiti@2.6.1)
       hermes-parser: 0.25.1
-      zod: 4.1.13
-      zod-validation-error: 4.0.2(zod@4.1.13)
+      zod: 4.3.6
+      zod-validation-error: 4.0.2(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
 
@@ -6241,8 +6244,8 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zod-validation-error@4.0.2(zod@4.1.13):
+  zod-validation-error@4.0.2(zod@4.3.6):
     dependencies:
-      zod: 4.1.13
+      zod: 4.3.6
 
-  zod@4.1.13: {}
+  zod@4.3.6: {}

--- a/src/components/settings/interval-input.tsx
+++ b/src/components/settings/interval-input.tsx
@@ -8,13 +8,20 @@ type IntervalInputProps = {
   prefix: string;
   label: string;
   defaultValue?: Interval | null;
+  error?: string;
 };
 
 export function IntervalInput({
   prefix,
   label,
   defaultValue,
+  error,
 }: IntervalInputProps) {
+  const errorId = `${prefix}-error`;
+  const hasError = error !== undefined && error !== '';
+  const ariaDescribedBy = hasError ? errorId : undefined;
+  const ariaInvalid = hasError ? true : undefined;
+
   return (
     <div className="space-y-2">
       <Label className="text-base font-medium">{label}</Label>
@@ -26,6 +33,8 @@ export function IntervalInput({
             min={0}
             defaultValue={defaultValue?.days ?? 0}
             className="w-20"
+            aria-invalid={ariaInvalid}
+            aria-describedby={ariaDescribedBy}
           />
           <span className="text-sm text-muted-foreground">日</span>
         </div>
@@ -37,6 +46,8 @@ export function IntervalInput({
             max={23}
             defaultValue={defaultValue?.hours ?? 0}
             className="w-20"
+            aria-invalid={ariaInvalid}
+            aria-describedby={ariaDescribedBy}
           />
           <span className="text-sm text-muted-foreground">時間</span>
         </div>
@@ -48,10 +59,17 @@ export function IntervalInput({
             max={59}
             defaultValue={defaultValue?.minutes ?? 0}
             className="w-20"
+            aria-invalid={ariaInvalid}
+            aria-describedby={ariaDescribedBy}
           />
           <span className="text-sm text-muted-foreground">分</span>
         </div>
       </div>
+      {hasError && (
+        <p id={errorId} className="text-sm text-destructive">
+          {error}
+        </p>
+      )}
     </div>
   );
 }

--- a/src/components/settings/settings-form.tsx
+++ b/src/components/settings/settings-form.tsx
@@ -3,8 +3,13 @@
 import { Button } from '@/components/ui/button';
 import type { SettingsActionState } from '@/lib/actions/settings-actions';
 import { saveSettingsAction } from '@/lib/actions/settings-actions';
+import {
+  mapZodErrorsToFieldErrors,
+  parseSettingsFormData,
+  type SettingsFieldErrors,
+} from '@/lib/validation/settings-schema';
 import type { Setting } from '@/types/api';
-import { useActionState, useEffect } from 'react';
+import { useActionState, useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { IntervalInput } from './interval-input';
 
@@ -24,18 +29,31 @@ export function SettingsForm({ setting }: SettingsFormProps) {
     FormData
   >(saveSettingsAction, {});
 
+  const [fieldErrors, setFieldErrors] = useState<SettingsFieldErrors>({});
+
   useEffect(() => {
     if (state.success === true) {
       toast.success('設定を保存しました');
     }
   }, [state.success]);
 
+  const handleAction = (formData: FormData) => {
+    const result = parseSettingsFormData(formData);
+    if (!result.success) {
+      setFieldErrors(mapZodErrorsToFieldErrors(result.error));
+      return;
+    }
+    setFieldErrors({});
+    formAction(formData);
+  };
+
   return (
-    <form action={formAction} className="space-y-8">
+    <form action={handleAction} className="space-y-8">
       <IntervalInput
         prefix="hard"
         label="難しい（Hard）の復習間隔"
         defaultValue={setting?.hard_interval ?? defaultIntervals.hard}
+        error={fieldErrors.hard}
       />
 
       <IntervalInput
@@ -44,12 +62,14 @@ export function SettingsForm({ setting }: SettingsFormProps) {
         defaultValue={
           setting?.uncertain_interval ?? defaultIntervals.uncertain
         }
+        error={fieldErrors.uncertain}
       />
 
       <IntervalInput
         prefix="easy"
         label="簡単（Easy）の復習間隔"
         defaultValue={setting?.easy_interval ?? defaultIntervals.easy}
+        error={fieldErrors.easy}
       />
 
       {state.errors !== undefined && state.errors.length > 0 && (

--- a/src/lib/actions/settings-actions.ts
+++ b/src/lib/actions/settings-actions.ts
@@ -2,7 +2,7 @@
 
 import { ApiError } from '@/lib/api/client';
 import { createSetting, getSetting, updateSetting } from '@/lib/api/settings';
-import type { Interval } from '@/types/api';
+import { parseSettingsFormData } from '@/lib/validation/settings-schema';
 import { revalidatePath } from 'next/cache';
 
 export type SettingsActionState = {
@@ -10,20 +10,16 @@ export type SettingsActionState = {
   success?: boolean;
 };
 
-function parseInterval(formData: FormData, prefix: string): Interval {
-  const days = Number(formData.get(`${prefix}_days`) ?? '0');
-  const hours = Number(formData.get(`${prefix}_hours`) ?? '0');
-  const minutes = Number(formData.get(`${prefix}_minutes`) ?? '0');
-  return { days, hours, minutes };
-}
-
 export async function saveSettingsAction(
   _prevState: SettingsActionState,
   formData: FormData,
 ): Promise<SettingsActionState> {
-  const hardInterval = parseInterval(formData, 'hard');
-  const uncertainInterval = parseInterval(formData, 'uncertain');
-  const easyInterval = parseInterval(formData, 'easy');
+  const parsed = parseSettingsFormData(formData);
+  if (!parsed.success) {
+    return { errors: parsed.error.issues.map((issue) => issue.message) };
+  }
+
+  const { hard_interval, uncertain_interval, easy_interval } = parsed.data;
 
   try {
     let existing;
@@ -39,15 +35,15 @@ export async function saveSettingsAction(
 
     if (existing !== undefined) {
       await updateSetting({
-        hard_interval: hardInterval,
-        uncertain_interval: uncertainInterval,
-        easy_interval: easyInterval,
+        hard_interval,
+        uncertain_interval,
+        easy_interval,
       });
     } else {
       await createSetting({
-        hard_interval: hardInterval,
-        uncertain_interval: uncertainInterval,
-        easy_interval: easyInterval,
+        hard_interval,
+        uncertain_interval,
+        easy_interval,
       });
     }
 

--- a/src/lib/validation/settings-schema.ts
+++ b/src/lib/validation/settings-schema.ts
@@ -1,0 +1,69 @@
+import { z } from 'zod';
+
+export const intervalSchema = z
+  .object({
+    days: z.coerce.number().int().min(0),
+    hours: z.coerce.number().int().min(0).max(23),
+    minutes: z.coerce.number().int().min(0).max(59),
+  })
+  .refine((v) => v.days * 1440 + v.hours * 60 + v.minutes >= 1, {
+    message: '1分以上を指定してください',
+  });
+
+export const settingsFormSchema = z.object({
+  hard_interval: intervalSchema,
+  uncertain_interval: intervalSchema,
+  easy_interval: intervalSchema,
+});
+
+export type SettingsFormValues = z.infer<typeof settingsFormSchema>;
+
+export type SettingsFieldErrors = Partial<
+  Record<'hard' | 'uncertain' | 'easy', string>
+>;
+
+export function parseSettingsFormData(formData: FormData) {
+  return settingsFormSchema.safeParse({
+    hard_interval: {
+      days: formData.get('hard_days'),
+      hours: formData.get('hard_hours'),
+      minutes: formData.get('hard_minutes'),
+    },
+    uncertain_interval: {
+      days: formData.get('uncertain_days'),
+      hours: formData.get('uncertain_hours'),
+      minutes: formData.get('uncertain_minutes'),
+    },
+    easy_interval: {
+      days: formData.get('easy_days'),
+      hours: formData.get('easy_hours'),
+      minutes: formData.get('easy_minutes'),
+    },
+  });
+}
+
+const intervalKeyToPrefix = {
+  hard_interval: 'hard',
+  uncertain_interval: 'uncertain',
+  easy_interval: 'easy',
+} as const;
+
+export function mapZodErrorsToFieldErrors(
+  error: z.ZodError,
+): SettingsFieldErrors {
+  const fieldErrors: SettingsFieldErrors = {};
+  for (const issue of error.issues) {
+    const top = issue.path[0];
+    if (
+      top === 'hard_interval' ||
+      top === 'uncertain_interval' ||
+      top === 'easy_interval'
+    ) {
+      const prefix = intervalKeyToPrefix[top];
+      if (fieldErrors[prefix] === undefined) {
+        fieldErrors[prefix] = issue.message;
+      }
+    }
+  }
+  return fieldErrors;
+}


### PR DESCRIPTION
## Summary
- Closes #29 — block submission when an SRS interval (hard / uncertain / easy) totals 0 and surface an inline message instead of a generic backend error.
- Introduce `zod` as a direct dependency and add a reusable schema in `src/lib/validation/settings-schema.ts` shared between the form and the server action.