### PR TITLE
chore: narrow WordWithFirstMeaning.first_meaning to API shape

### DIFF
--- a/src/components/word/word-card.tsx
+++ b/src/components/word/word-card.tsx
@@ -1,11 +1,11 @@
 import { Card, CardContent } from '@/components/ui/card';
-import type { Meaning, Word } from '@/types/api';
+import type { Word } from '@/types/api';
 import Link from 'next/link';
 import { WordStatusBadge } from './word-status-badge';
 
 type WordCardProps = {
   word: Word;
-  meaning?: Meaning;
+  meaning?: { definition: string };
   wordbookId: number;
 };
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -33,7 +33,7 @@ export type Meaning = {
 };
 
 export type WordWithFirstMeaning = Word & {
-  first_meaning: Meaning | null;
+  first_meaning: { definition: string } | null;
 };
 
 export type WordWithDetails = Word & {


### PR DESCRIPTION
## Summary
- Narrow `WordWithFirstMeaning.first_meaning` from `Meaning | null` to `{ definition: string } | null` so the frontend type matches the OpenAPI response shape.
- Update `WordCard`'s `meaning` prop to the same narrow shape; all existing call sites only read `definition`, so no logic changes are needed.

Closes #34