### PR TITLE
chore: nest examples under meanings to match OpenAPI schema

### DIFF
--- a/src/app/(authenticated)/wordbooks/[wordbookId]/test/page.tsx
+++ b/src/app/(authenticated)/wordbooks/[wordbookId]/test/page.tsx
@@ -26,15 +26,17 @@ async function TestContent({ wordbookId }: { wordbookId: string }) {
   const { wordbook, words } = data;
 
   const wordsWithRelations = words.map((w) => {
-    const { meanings, examples, ...word } = w;
+    const { meanings, ...word } = w;
     return {
       word,
-      meanings: meanings.sort(
-        (a, b) => a.display_order - b.display_order,
-      ),
-      examples: examples.sort(
-        (a, b) => a.display_order - b.display_order,
-      ),
+      meanings: [...meanings]
+        .sort((a, b) => a.display_order - b.display_order)
+        .map((meaning) => ({
+          ...meaning,
+          examples: [...meaning.examples].sort(
+            (a, b) => a.display_order - b.display_order,
+          ),
+        })),
     };
   });
 

--- a/src/app/(authenticated)/wordbooks/[wordbookId]/words/[wordId]/edit/page.tsx
+++ b/src/app/(authenticated)/wordbooks/[wordbookId]/words/[wordId]/edit/page.tsx
@@ -33,12 +33,16 @@ async function EditWordContent({
     notFound();
   }
 
-  const sortedMeanings = word.meanings.sort(
+  const sortedMeanings = [...word.meanings].sort(
     (a, b) => a.display_order - b.display_order,
   );
-  const sortedExamples = word.examples.sort(
-    (a, b) => a.display_order - b.display_order,
-  );
+  const firstMeaning = sortedMeanings[0];
+  const firstExample =
+    firstMeaning !== undefined
+      ? [...firstMeaning.examples].sort(
+          (a, b) => a.display_order - b.display_order,
+        )[0]
+      : undefined;
 
   return (
     <Card>
@@ -49,8 +53,8 @@ async function EditWordContent({
         <WordForm
           wordbookId={Number(wordbookId)}
           word={word}
-          meaning={sortedMeanings[0]}
-          example={sortedExamples[0]}
+          meaning={firstMeaning}
+          example={firstExample}
         />
       </CardContent>
     </Card>

--- a/src/app/(authenticated)/wordbooks/[wordbookId]/words/[wordId]/word-detail-content.tsx
+++ b/src/app/(authenticated)/wordbooks/[wordbookId]/words/[wordId]/word-detail-content.tsx
@@ -23,12 +23,14 @@ export async function WordDetailContent({
     notFound();
   }
 
-  const sortedMeanings = word.meanings.sort(
-    (a, b) => a.display_order - b.display_order,
-  );
-  const sortedExamples = word.examples.sort(
-    (a, b) => a.display_order - b.display_order,
-  );
+  const sortedMeanings = [...word.meanings]
+    .sort((a, b) => a.display_order - b.display_order)
+    .map((meaning) => ({
+      ...meaning,
+      examples: [...meaning.examples].sort(
+        (a, b) => a.display_order - b.display_order,
+      ),
+    }));
 
   return (
     <>
@@ -53,11 +55,7 @@ export async function WordDetailContent({
 
       <Card>
         <CardContent className="pt-6">
-          <WordDetail
-            word={word}
-            meanings={sortedMeanings}
-            examples={sortedExamples}
-          />
+          <WordDetail word={word} meanings={sortedMeanings} />
         </CardContent>
       </Card>
     </>

--- a/src/components/test/flashcard-test.tsx
+++ b/src/components/test/flashcard-test.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { Example, Meaning, Word } from '@/types/api';
+import type { Meaning, Word } from '@/types/api';
 import { evaluateWordAction } from '@/lib/actions/word-actions';
 import { useState, useTransition } from 'react';
 import { toast } from 'sonner';
@@ -11,7 +11,6 @@ import { TestComplete } from './test-complete';
 type WordWithRelations = {
   word: Word;
   meanings: Meaning[];
-  examples: Example[];
 };
 
 type FlashcardTestProps = {
@@ -76,7 +75,6 @@ export function FlashcardTest({ words, wordbookId }: FlashcardTestProps) {
         key={current.word.id}
         word={current.word}
         meanings={current.meanings}
-        examples={current.examples}
       />
 
       <SelfEvaluationButtons

--- a/src/components/test/flashcard.tsx
+++ b/src/components/test/flashcard.tsx
@@ -6,24 +6,19 @@ import { useState } from 'react';
 import { AudioPlayButton } from '@/components/audio/audio-play-button';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
-import type { Example, Meaning, Word } from '@/types/api';
+import type { Meaning, Word } from '@/types/api';
 
 type FlashcardProps = {
   word: Word;
   meanings: Meaning[];
-  examples: Example[];
 };
 
-export function Flashcard({ word, meanings, examples }: FlashcardProps) {
+export function Flashcard({ word, meanings }: FlashcardProps) {
   const [isFlipped, setIsFlipped] = useState(false);
   const [meaningsExpanded, setMeaningsExpanded] = useState(false);
-  const [examplesExpanded, setExamplesExpanded] = useState(false);
 
   const visibleMeanings = meaningsExpanded ? meanings : meanings.slice(0, 3);
   const hiddenMeaningsCount = meanings.length - 3;
-
-  const visibleExamples = examplesExpanded ? examples : examples.slice(0, 2);
-  const hiddenExamplesCount = examples.length - 2;
 
   return (
     <div
@@ -48,18 +43,40 @@ export function Flashcard({ word, meanings, examples }: FlashcardProps) {
                 {word.spelling}
               </p>
               {meanings.length > 0 && (
-                <div className="space-y-1">
+                <div className="space-y-3">
                   {visibleMeanings.map((meaning, index) => (
-                    <p
-                      key={meaning.id}
-                      className={
-                        index === 0
-                          ? 'text-2xl font-bold'
-                          : 'text-base text-muted-foreground'
-                      }
-                    >
-                      {meaning.definition}
-                    </p>
+                    <div key={meaning.id} className="space-y-1">
+                      <p
+                        className={
+                          index === 0
+                            ? 'text-2xl font-bold'
+                            : 'text-base text-muted-foreground'
+                        }
+                      >
+                        {meaning.definition}
+                      </p>
+                      {meaning.examples.length > 0 && (
+                        <div className="space-y-1">
+                          {meaning.examples.map((example) => (
+                            <div
+                              key={example.id}
+                              className={
+                                index === 0
+                                  ? 'text-sm'
+                                  : 'text-xs text-muted-foreground'
+                              }
+                            >
+                              <p className="text-foreground">
+                                {example.sentence}
+                              </p>
+                              <p className="text-muted-foreground">
+                                {example.translation}
+                              </p>
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                    </div>
                   ))}
                   {hiddenMeaningsCount > 0 && (
                     <div onClick={(e) => e.stopPropagation()}>
@@ -76,45 +93,6 @@ export function Flashcard({ word, meanings, examples }: FlashcardProps) {
                         ) : (
                           <>
                             <ChevronDown />+{hiddenMeaningsCount} more
-                          </>
-                        )}
-                      </Button>
-                    </div>
-                  )}
-                </div>
-              )}
-              {examples.length > 0 && (
-                <div className="mt-4 space-y-2">
-                  {visibleExamples.map((example, index) => (
-                    <div
-                      key={example.id}
-                      className={
-                        index === 0
-                          ? 'text-sm'
-                          : 'text-xs text-muted-foreground'
-                      }
-                    >
-                      <p className="text-foreground">{example.sentence}</p>
-                      <p className="text-muted-foreground">
-                        {example.translation}
-                      </p>
-                    </div>
-                  ))}
-                  {hiddenExamplesCount > 0 && (
-                    <div onClick={(e) => e.stopPropagation()}>
-                      <Button
-                        variant="ghost"
-                        size="xs"
-                        onClick={() => setExamplesExpanded(!examplesExpanded)}
-                      >
-                        {examplesExpanded ? (
-                          <>
-                            <ChevronUp />
-                            閉じる
-                          </>
-                        ) : (
-                          <>
-                            <ChevronDown />+{hiddenExamplesCount} more
                           </>
                         )}
                       </Button>

--- a/src/components/word/word-detail.tsx
+++ b/src/components/word/word-detail.tsx
@@ -1,15 +1,14 @@
 import { Separator } from '@/components/ui/separator';
 import { AudioPlayButton } from '@/components/audio/audio-play-button';
-import type { Example, Meaning, Word } from '@/types/api';
+import type { Meaning, Word } from '@/types/api';
 import { WordStatusBadge } from './word-status-badge';
 
 type WordDetailProps = {
   word: Word;
   meanings: Meaning[];
-  examples: Example[];
 };
 
-export function WordDetail({ word, meanings, examples }: WordDetailProps) {
+export function WordDetail({ word, meanings }: WordDetailProps) {
   return (
     <div className="space-y-6">
       <div className="flex items-center gap-3">
@@ -23,35 +22,26 @@ export function WordDetail({ word, meanings, examples }: WordDetailProps) {
           <h3 className="text-sm font-medium text-muted-foreground mb-2">
             意味
           </h3>
-          <ul className="space-y-1">
+          <ul className="space-y-4">
             {meanings.map((meaning) => (
-              <li key={meaning.id} className="text-lg">
-                {meaning.definition}
+              <li key={meaning.id} className="space-y-2">
+                <p className="text-lg">{meaning.definition}</p>
+                {meaning.examples.length > 0 && (
+                  <ul className="space-y-2 pl-4 border-l-2 border-muted">
+                    {meaning.examples.map((example) => (
+                      <li key={example.id} className="space-y-1">
+                        <p className="text-base">{example.sentence}</p>
+                        <p className="text-sm text-muted-foreground">
+                          {example.translation}
+                        </p>
+                      </li>
+                    ))}
+                  </ul>
+                )}
               </li>
             ))}
           </ul>
         </div>
-      )}
-
-      {examples.length > 0 && (
-        <>
-          <Separator />
-          <div>
-            <h3 className="text-sm font-medium text-muted-foreground mb-2">
-              例文
-            </h3>
-            <ul className="space-y-3">
-              {examples.map((example) => (
-                <li key={example.id} className="space-y-1">
-                  <p className="text-base">{example.sentence}</p>
-                  <p className="text-sm text-muted-foreground">
-                    {example.translation}
-                  </p>
-                </li>
-              ))}
-            </ul>
-          </div>
-        </>
       )}
 
       {word.next_review_at !== null && (

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -26,10 +26,18 @@ export type Word = {
   next_review_at: string | null;
 };
 
+export type Example = {
+  id: number;
+  sentence: string;
+  translation: string;
+  display_order: number;
+};
+
 export type Meaning = {
   id: number;
   definition: string;
   display_order: number;
+  examples: Example[];
 };
 
 export type WordWithFirstMeaning = Word & {
@@ -38,19 +46,11 @@ export type WordWithFirstMeaning = Word & {
 
 export type WordWithDetails = Word & {
   meanings: Meaning[];
-  examples: Example[];
 };
 
 export type TestWordsResponse = {
   wordbook: Wordbook;
   words: WordWithDetails[];
-};
-
-export type Example = {
-  id: number;
-  sentence: string;
-  translation: string;
-  display_order: number;
 };
 
 export type Setting = {


### PR DESCRIPTION
## Summary

- Nest `Example` under `Meaning` as `examples: Example[]` and drop `WordWithDetails.examples` so the domain types match the OpenAPI `WordWithRelations` schema.
- Render each meaning's examples inline on the word detail and flashcard test screens.
- On the edit page, source the first example from the first meaning's nested examples.

Closes #32

## Test plan

- [ ] `pnpm lint` passes
- [ ] `pnpm exec tsc --noEmit` passes
- [ ] With `pnpm dev` and the Rails backend running, manually verify:
  - [ ] Word detail page shows examples nested under each meaning
  - [ ] Flashcard test back face shows examples nested under each meaning
  - [ ] Word edit page loads the existing example as the initial value and can save it
  - [ ] Words with no examples render without layout breakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)