### PR TITLE
fix: support pagination envelope on list endpoints

### DIFF
--- a/src/components/word/word-list.tsx
+++ b/src/components/word/word-list.tsx
@@ -9,7 +9,7 @@ type WordListProps = {
 };
 
 export async function WordList({ wordbookId, status, query }: WordListProps) {
-  const allWords = await listWords(wordbookId);
+  const { data: allWords } = await listWords(wordbookId);
 
   let filteredWords: WordWithFirstMeaning[] = allWords;
 

--- a/src/components/wordbook/wordbook-list.tsx
+++ b/src/components/wordbook/wordbook-list.tsx
@@ -2,7 +2,7 @@ import { listWordbooks } from '@/lib/api/wordbooks';
 import { WordbookCard } from './wordbook-card';
 
 export async function WordbookList() {
-  const wordbooks = await listWordbooks();
+  const { data: wordbooks } = await listWordbooks();
 
   if (wordbooks.length === 0) {
     return (

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -37,6 +37,23 @@ type RequestOptions = {
   body?: unknown;
 };
 
+export type ListParams = {
+  page?: number;
+  perPage?: number;
+};
+
+export function buildListPath(base: string, params?: ListParams): string {
+  const search = new URLSearchParams();
+  if (params?.page !== undefined) {
+    search.set('page', String(params.page));
+  }
+  if (params?.perPage !== undefined) {
+    search.set('per_page', String(params.perPage));
+  }
+  const qs = search.toString();
+  return qs === '' ? base : `${base}?${qs}`;
+}
+
 export async function apiRequest<T>(options: RequestOptions): Promise<T> {
   const token = await getToken();
   const baseUrl = getBaseUrl();

--- a/src/lib/api/examples.ts
+++ b/src/lib/api/examples.ts
@@ -1,18 +1,23 @@
 import type {
   CreateExampleInput,
   Example,
+  PaginatedResponse,
   UpdateExampleInput,
 } from '@/types/api';
-import { apiRequest } from './client';
+import { apiRequest, buildListPath, type ListParams } from './client';
 
 export function listExamples(
   wordbookId: number,
   wordId: number,
   meaningId: number,
-): Promise<Example[]> {
+  params?: ListParams,
+): Promise<PaginatedResponse<Example>> {
   return apiRequest({
     method: 'GET',
-    path: `/wordbooks/${wordbookId}/words/${wordId}/meanings/${meaningId}/examples`,
+    path: buildListPath(
+      `/wordbooks/${wordbookId}/words/${wordId}/meanings/${meaningId}/examples`,
+      params,
+    ),
   });
 }
 

--- a/src/lib/api/meanings.ts
+++ b/src/lib/api/meanings.ts
@@ -1,17 +1,22 @@
 import type {
   CreateMeaningInput,
   Meaning,
+  PaginatedResponse,
   UpdateMeaningInput,
 } from '@/types/api';
-import { apiRequest } from './client';
+import { apiRequest, buildListPath, type ListParams } from './client';
 
 export function listMeanings(
   wordbookId: number,
   wordId: number,
-): Promise<Meaning[]> {
+  params?: ListParams,
+): Promise<PaginatedResponse<Meaning>> {
   return apiRequest({
     method: 'GET',
-    path: `/wordbooks/${wordbookId}/words/${wordId}/meanings`,
+    path: buildListPath(
+      `/wordbooks/${wordbookId}/words/${wordId}/meanings`,
+      params,
+    ),
   });
 }
 

--- a/src/lib/api/wordbooks.ts
+++ b/src/lib/api/wordbooks.ts
@@ -1,12 +1,18 @@
 import type {
   CreateWordbookInput,
+  PaginatedResponse,
   UpdateWordbookInput,
   Wordbook,
 } from '@/types/api';
-import { apiRequest } from './client';
+import { apiRequest, buildListPath, type ListParams } from './client';
 
-export function listWordbooks(): Promise<Wordbook[]> {
-  return apiRequest({ method: 'GET', path: '/wordbooks' });
+export function listWordbooks(
+  params?: ListParams,
+): Promise<PaginatedResponse<Wordbook>> {
+  return apiRequest({
+    method: 'GET',
+    path: buildListPath('/wordbooks', params),
+  });
 }
 
 export function getWordbook(id: number): Promise<Wordbook> {

--- a/src/lib/api/words.ts
+++ b/src/lib/api/words.ts
@@ -1,17 +1,22 @@
 import type {
   CreateWordInput,
+  PaginatedResponse,
   TestWordsResponse,
   UpdateWordInput,
   Word,
   WordWithDetails,
   WordWithFirstMeaning,
 } from '@/types/api';
-import { apiRequest } from './client';
+import { apiRequest, buildListPath, type ListParams } from './client';
 
 export function listWords(
   wordbookId: number,
-): Promise<WordWithFirstMeaning[]> {
-  return apiRequest({ method: 'GET', path: `/wordbooks/${wordbookId}/words` });
+  params?: ListParams,
+): Promise<PaginatedResponse<WordWithFirstMeaning>> {
+  return apiRequest({
+    method: 'GET',
+    path: buildListPath(`/wordbooks/${wordbookId}/words`, params),
+  });
 }
 
 export function getWord(wordbookId: number, id: number): Promise<Word> {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,5 +1,17 @@
 export type WordStatus = 'not_studied' | 'hard' | 'uncertain' | 'easy';
 
+export type Pagination = {
+  current_page: number;
+  total_pages: number;
+  total_count: number;
+  per_page: number;
+};
+
+export type PaginatedResponse<T> = {
+  data: T[];
+  pagination: Pagination;
+};
+
 export type Interval = {
   days: number;
   hours: number;


### PR DESCRIPTION
## Summary
- Update list API modules (`wordbooks` / `words` / `meanings` / `examples`) to return `{ data, pagination }` matching the OpenAPI response shape, fixing the runtime crash where consumers called `.map` / `.filter` on the bare envelope object.
- Add `Pagination` / `PaginatedResponse<T>` types and a `buildListPath` helper with optional `page` / `per_page` query parameter support.
- Closes #33