### PR TITLE
refactor: create word with nested meanings/examples in one request

### DIFF
--- a/docs/api-frontend-mismatches.md
+++ b/docs/api-frontend-mismatches.md
@@ -150,13 +150,14 @@ properties: { spelling, meanings_attributes }
 
 ## Medium — 型定義の余剰 / 最適化漏れ
 
-### 7. Word の作成で nested attributes を活用していない(N+1 リクエスト)
+### 7. Word の作成で nested attributes を活用していない(N+1 リクエスト) ✅ 解消済み (#35)
 
 OpenAPI POST `/words` は `meanings_attributes` + ネストした `examples_attributes` を 1 トランザクションで受け付ける。
 
 `src/lib/actions/word-actions.ts:33-57` は word → meaning → example を逐次 3 リクエスト発行。
 
 → 1 リクエストにまとめると、原子性が担保され、ネットワーク往復も削減できる。
+→ `createWordAction` で `meanings_attributes`(内側に `examples_attributes`)を組み立て、`createWord` 1 回で送信するよう変更。
 
 ---
 

--- a/src/lib/actions/word-actions.ts
+++ b/src/lib/actions/word-actions.ts
@@ -4,7 +4,11 @@ import { ApiError } from '@/lib/api/client';
 import { createExample, updateExample } from '@/lib/api/examples';
 import { createMeaning, updateMeaning } from '@/lib/api/meanings';
 import { createWord, deleteWord, updateWord } from '@/lib/api/words';
-import type { Meaning, WordStatus } from '@/types/api';
+import type {
+  CreateExampleNestedInput,
+  CreateMeaningNestedInput,
+  WordStatus,
+} from '@/types/api';
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 
@@ -30,32 +34,39 @@ export async function createWordAction(
     return { errors: ['単語帳が見つかりません'] };
   }
 
+  const trimmedMeaning =
+    typeof meaningContent === 'string' ? meaningContent.trim() : '';
+  const trimmedSentence =
+    typeof exampleSentence === 'string' ? exampleSentence.trim() : '';
+  const trimmedTranslation =
+    typeof exampleTranslation === 'string' ? exampleTranslation.trim() : '';
+
+  let meanings_attributes: CreateMeaningNestedInput[] | undefined;
+  if (trimmedMeaning !== '') {
+    let examples_attributes: CreateExampleNestedInput[] | undefined;
+    if (trimmedSentence !== '' && trimmedTranslation !== '') {
+      examples_attributes = [
+        {
+          sentence: trimmedSentence,
+          translation: trimmedTranslation,
+          display_order: 1,
+        },
+      ];
+    }
+    meanings_attributes = [
+      {
+        definition: trimmedMeaning,
+        display_order: 1,
+        examples_attributes,
+      },
+    ];
+  }
+
   try {
-    const word = await createWord(Number(wordbookId), {
+    await createWord(Number(wordbookId), {
       spelling: spelling.trim(),
+      meanings_attributes,
     });
-
-    let createdMeaning: Meaning | undefined;
-    if (typeof meaningContent === 'string' && meaningContent.trim() !== '') {
-      createdMeaning = await createMeaning(Number(wordbookId), word.id, {
-        definition: meaningContent.trim(),
-        display_order: 1,
-      });
-    }
-
-    if (
-      createdMeaning !== undefined &&
-      typeof exampleSentence === 'string' &&
-      exampleSentence.trim() !== '' &&
-      typeof exampleTranslation === 'string' &&
-      exampleTranslation.trim() !== ''
-    ) {
-      await createExample(Number(wordbookId), word.id, createdMeaning.id, {
-        sentence: exampleSentence.trim(),
-        translation: exampleTranslation.trim(),
-        display_order: 1,
-      });
-    }
 
     revalidatePath(`/wordbooks/${wordbookId}`);
     revalidatePath(`/wordbooks/${wordbookId}/test`);

--- a/src/lib/api/words.ts
+++ b/src/lib/api/words.ts
@@ -48,7 +48,7 @@ export function getTestWords(
 export function createWord(
   wordbookId: number,
   input: CreateWordInput,
-): Promise<Word> {
+): Promise<WordWithDetails> {
   return apiRequest({
     method: 'POST',
     path: `/wordbooks/${wordbookId}/words`,

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -79,10 +79,23 @@ export type UpdateWordbookInput = {
   title?: string;
 };
 
+export type CreateExampleNestedInput = {
+  sentence: string;
+  translation: string;
+  display_order: number;
+};
+
+export type CreateMeaningNestedInput = {
+  definition: string;
+  display_order: number;
+  examples_attributes?: CreateExampleNestedInput[];
+};
+
 export type CreateWordInput = {
   spelling: string;
   status?: WordStatus;
   next_review_at?: string | null;
+  meanings_attributes?: CreateMeaningNestedInput[];
 };
 
 export type UpdateWordInput = {


### PR DESCRIPTION
## Summary
- Build `meanings_attributes` (with nested `examples_attributes`) in `createWordAction` and send a single `POST /wordbooks/:id/words` instead of three sequential requests.
- Preserves atomicity (no half-created words on partial failure) and removes two network round-trips.
- Closes #35.