### PR TITLE
refactor(auth): hand-write provider id/name and tighten provider types

### DIFF
--- a/src/components/auth/auth-form.tsx
+++ b/src/components/auth/auth-form.tsx
@@ -38,7 +38,7 @@ export function AuthForm() {
       </CardHeader>
       <CardContent className="space-y-6 pb-8">
         <div className="space-y-4">
-          {Object.values(providers).map((provider) => (
+          {providers.map((provider) => (
             <form key={provider.id} action={signInAction}>
               <input type="hidden" name="providerId" value={provider.id} />
               <Button

--- a/src/lib/auth/actions.ts
+++ b/src/lib/auth/actions.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { signIn, signOut } from '@/lib/auth';
-import { getProviderIds } from '@/lib/auth/providers';
+import { isProviderId } from '@/lib/auth/providers';
 import { AuthError } from 'next-auth';
 import { redirect } from 'next/navigation';
 
@@ -14,7 +14,7 @@ export async function signInAction(formData: FormData) {
     throw new Error('providerId must be a string');
   }
 
-  if (!getProviderIds().includes(providerId)) {
+  if (!isProviderId(providerId)) {
     throw new Error(`Invalid provider: ${providerId}`);
   }
 

--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -1,12 +1,9 @@
 import NextAuth from 'next-auth';
-import type { Provider } from 'next-auth/providers';
 import Credentials from 'next-auth/providers/credentials';
 import { createGuestUser } from '@/data/guest-user';
 import type { AuthResponse } from '@/types/dto';
 import { getAndClearGuestTokenCookie } from './guest-migration';
-import { getAuthJsProviders } from './providers';
-
-const oauthProviders: Provider[] = getAuthJsProviders();
+import { authJsProviders } from './providers';
 
 const guestProvider = Credentials({
   id: 'guest',
@@ -23,7 +20,7 @@ const guestProvider = Credentials({
 });
 
 export const { handlers, signIn, signOut, auth } = NextAuth({
-  providers: [...oauthProviders, guestProvider],
+  providers: [...authJsProviders, guestProvider],
   pages: {
     signIn: '/auth',
   },

--- a/src/lib/auth/providers.ts
+++ b/src/lib/auth/providers.ts
@@ -5,62 +5,27 @@ import type { IconType } from 'react-icons';
 import { FaGithub } from 'react-icons/fa';
 import { FcGoogle } from 'react-icons/fc';
 
-type ProviderIconAssociation = {
-  provider: AuthJsProvider;
-  icon: IconType;
-};
-
-const providerIconAssociations: ProviderIconAssociation[] = [
-  {
-    provider: Google,
-    icon: FcGoogle,
-  },
-  {
-    provider: GitHub,
-    icon: FaGithub,
-  },
-];
-
-export type Provider = {
+type ProviderEntry = {
   id: string;
   name: string;
   authJsProvider: AuthJsProvider;
   icon: IconType;
 };
 
-export const providers = Object.fromEntries(
-  providerIconAssociations
-    .map((item) => {
-      if (typeof item.provider === 'function') {
-        const providerData = item.provider();
-        return [
-          providerData.id,
-          {
-            id: providerData.id,
-            name: providerData.name,
-            authJsProvider: item.provider,
-            icon: item.icon,
-          } as Provider,
-        ];
-      } else {
-        return [
-          item.provider.id,
-          {
-            id: item.provider.id,
-            name: item.provider.name,
-            authJsProvider: item.provider,
-            icon: item.icon,
-          } as Provider,
-        ];
-      }
-    })
-    .filter(([id]) => id !== 'credentials')
-) as Record<string, Provider>;
+// Register a new OAuth provider by adding an entry here.
+export const providers = [
+  { id: 'google', name: 'Google', authJsProvider: Google, icon: FcGoogle },
+  { id: 'github', name: 'GitHub', authJsProvider: GitHub, icon: FaGithub },
+] as const satisfies readonly ProviderEntry[];
 
-export const getAuthJsProviders = (): AuthJsProvider[] => {
-  return Object.values(providers).map((p) => p.authJsProvider);
-};
+export type Provider = (typeof providers)[number];
+export type ProviderId = Provider['id'];
 
-export const getProviderIds = (): string[] => {
-  return Object.values(providers).map((p) => p.id);
-};
+const providerIds: readonly ProviderId[] = providers.map((p) => p.id);
+
+export const authJsProviders: readonly AuthJsProvider[] = providers.map(
+  (p) => p.authJsProvider
+);
+
+export const isProviderId = (id: string): id is ProviderId =>
+  (providerIds as readonly string[]).includes(id);


### PR DESCRIPTION
## Summary

- Replace the `Record<string, Provider>` registry — built by invoking each Auth.js factory at module load just to read `id`/`name` — with a plain array whose entries hand-write `id` and `name`.
- Use `as const satisfies readonly ProviderEntry[]` so `id`/`name` keep their literal types; derive `Provider` and `ProviderId` from `typeof providers` to make the array the single source of truth.
- Add an `isProviderId` type guard and call it from `signInAction`, replacing the looser `getProviderIds().includes(...)` check.
- Drop the now-unused `credentials` filter, the `if (typeof item.provider === 'function')` branch, the `as Provider` cast, and the `getProviderIds` / `getAuthJsProviders` getters.
- `authJsProvider` still stores the unresolved factory (`Google` / `GitHub`), matching the Auth.js v5 official function-form recommendation, so env-var injection inside `setEnvDefaults` is unaffected.

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm build` passes; `Provider` / `ProviderId` are inferred as literal unions
- [x] `/auth` renders Google and GitHub buttons with their icons and labels
- [x] Manual: Google sign-in completes the OAuth round-trip end-to-end
- [x] Manual: Guest sign-in still works (regression check)
- [x] Manual: `signInAction` rejects an invalid `providerId` via the `isProviderId` guard

Closes #65
Closes #63
Closes #64