### PR TITLE
feat(dashboard): paginate wordbook list via ?page param

### DIFF
--- a/src/app/(authenticated)/dashboard/page.tsx
+++ b/src/app/(authenticated)/dashboard/page.tsx
@@ -11,7 +11,23 @@ export const metadata: Metadata = {
   title: 'ダッシュボード | WordBeetle',
 };
 
-export default function DashboardPage() {
+type SearchParams = Promise<{ page?: string }>;
+
+function parsePage(raw: string | undefined): number {
+  if (raw === undefined) return 1;
+  const parsed = Number.parseInt(raw, 10);
+  if (Number.isNaN(parsed) || parsed < 1) return 1;
+  return parsed;
+}
+
+export default async function DashboardPage({
+  searchParams,
+}: {
+  searchParams: SearchParams;
+}) {
+  const { page: pageParam } = await searchParams;
+  const page = parsePage(pageParam);
+
   return (
     <div className="min-h-screen bg-background">
       <div className="max-w-4xl mx-auto px-4 py-8">
@@ -28,6 +44,7 @@ export default function DashboardPage() {
           </Button>
         </div>
         <Suspense
+          key={page}
           fallback={
             <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
               {Array.from({ length: 6 }).map((_, i) => (
@@ -36,7 +53,7 @@ export default function DashboardPage() {
             </div>
           }
         >
-          <WordbookList />
+          <WordbookList page={page} />
         </Suspense>
       </div>
     </div>

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -1,0 +1,127 @@
+import * as React from "react"
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  MoreHorizontalIcon,
+} from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants, type Button } from "@/components/ui/button"
+
+function Pagination({ className, ...props }: React.ComponentProps<"nav">) {
+  return (
+    <nav
+      role="navigation"
+      aria-label="pagination"
+      data-slot="pagination"
+      className={cn("mx-auto flex w-full justify-center", className)}
+      {...props}
+    />
+  )
+}
+
+function PaginationContent({
+  className,
+  ...props
+}: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="pagination-content"
+      className={cn("flex flex-row items-center gap-1", className)}
+      {...props}
+    />
+  )
+}
+
+function PaginationItem({ ...props }: React.ComponentProps<"li">) {
+  return <li data-slot="pagination-item" {...props} />
+}
+
+type PaginationLinkProps = {
+  isActive?: boolean
+} & Pick<React.ComponentProps<typeof Button>, "size"> &
+  React.ComponentProps<"a">
+
+function PaginationLink({
+  className,
+  isActive,
+  size = "icon",
+  ...props
+}: PaginationLinkProps) {
+  return (
+    <a
+      aria-current={isActive ? "page" : undefined}
+      data-slot="pagination-link"
+      data-active={isActive}
+      className={cn(
+        buttonVariants({
+          variant: isActive ? "outline" : "ghost",
+          size,
+        }),
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function PaginationPrevious({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) {
+  return (
+    <PaginationLink
+      aria-label="Go to previous page"
+      size="default"
+      className={cn("gap-1 px-2.5 sm:pl-2.5", className)}
+      {...props}
+    >
+      <ChevronLeftIcon />
+      <span className="hidden sm:block">Previous</span>
+    </PaginationLink>
+  )
+}
+
+function PaginationNext({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) {
+  return (
+    <PaginationLink
+      aria-label="Go to next page"
+      size="default"
+      className={cn("gap-1 px-2.5 sm:pr-2.5", className)}
+      {...props}
+    >
+      <span className="hidden sm:block">Next</span>
+      <ChevronRightIcon />
+    </PaginationLink>
+  )
+}
+
+function PaginationEllipsis({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      aria-hidden
+      data-slot="pagination-ellipsis"
+      className={cn("flex size-9 items-center justify-center", className)}
+      {...props}
+    >
+      <MoreHorizontalIcon className="size-4" />
+      <span className="sr-only">More pages</span>
+    </span>
+  )
+}
+
+export {
+  Pagination,
+  PaginationContent,
+  PaginationLink,
+  PaginationItem,
+  PaginationPrevious,
+  PaginationNext,
+  PaginationEllipsis,
+}

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -4,6 +4,7 @@ import {
   ChevronRightIcon,
   MoreHorizontalIcon,
 } from "lucide-react"
+import Link from "next/link"
 
 import { cn } from "@/lib/utils"
 import { buttonVariants, type Button } from "@/components/ui/button"
@@ -40,7 +41,7 @@ function PaginationItem({ ...props }: React.ComponentProps<"li">) {
 type PaginationLinkProps = {
   isActive?: boolean
 } & Pick<React.ComponentProps<typeof Button>, "size"> &
-  React.ComponentProps<"a">
+  React.ComponentProps<typeof Link>
 
 function PaginationLink({
   className,
@@ -49,13 +50,13 @@ function PaginationLink({
   ...props
 }: PaginationLinkProps) {
   return (
-    <a
-      aria-current={isActive ? "page" : undefined}
+    <Link
+      aria-current={isActive === true ? "page" : undefined}
       data-slot="pagination-link"
       data-active={isActive}
       className={cn(
         buttonVariants({
-          variant: isActive ? "outline" : "ghost",
+          variant: isActive === true ? "outline" : "ghost",
           size,
         }),
         className

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -72,13 +72,13 @@ function PaginationPrevious({
 }: React.ComponentProps<typeof PaginationLink>) {
   return (
     <PaginationLink
-      aria-label="Go to previous page"
+      aria-label="前のページへ"
       size="default"
       className={cn("gap-1 px-2.5 sm:pl-2.5", className)}
       {...props}
     >
       <ChevronLeftIcon />
-      <span className="hidden sm:block">Previous</span>
+      <span className="hidden sm:block">前へ</span>
     </PaginationLink>
   )
 }
@@ -89,12 +89,12 @@ function PaginationNext({
 }: React.ComponentProps<typeof PaginationLink>) {
   return (
     <PaginationLink
-      aria-label="Go to next page"
+      aria-label="次のページへ"
       size="default"
       className={cn("gap-1 px-2.5 sm:pr-2.5", className)}
       {...props}
     >
-      <span className="hidden sm:block">Next</span>
+      <span className="hidden sm:block">次へ</span>
       <ChevronRightIcon />
     </PaginationLink>
   )

--- a/src/components/wordbook/wordbook-list.tsx
+++ b/src/components/wordbook/wordbook-list.tsx
@@ -1,10 +1,30 @@
 import { listWordbooks } from '@/lib/api/wordbooks';
 import { WordbookCard } from './wordbook-card';
+import { WordbookPagination } from './wordbook-pagination';
 
-export async function WordbookList() {
-  const { data: wordbooks } = await listWordbooks();
+const PER_PAGE = 12;
+
+type Props = {
+  page?: number;
+};
+
+export async function WordbookList({ page = 1 }: Props) {
+  const { data: wordbooks, pagination } = await listWordbooks({
+    page,
+    perPage: PER_PAGE,
+  });
 
   if (wordbooks.length === 0) {
+    if (page > 1) {
+      return (
+        <div className="text-center py-16">
+          <p className="text-muted-foreground text-lg">
+            このページに単語帳がありません。
+          </p>
+          <WordbookPagination pagination={pagination} />
+        </div>
+      );
+    }
     return (
       <div className="text-center py-16">
         <p className="text-muted-foreground text-lg">
@@ -15,10 +35,13 @@ export async function WordbookList() {
   }
 
   return (
-    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-      {wordbooks.map((wordbook) => (
-        <WordbookCard key={wordbook.id} wordbook={wordbook} />
-      ))}
-    </div>
+    <>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {wordbooks.map((wordbook) => (
+          <WordbookCard key={wordbook.id} wordbook={wordbook} />
+        ))}
+      </div>
+      <WordbookPagination pagination={pagination} />
+    </>
   );
 }

--- a/src/components/wordbook/wordbook-pagination.tsx
+++ b/src/components/wordbook/wordbook-pagination.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from '@/components/ui/pagination';
+import type { Pagination as PaginationMeta } from '@/types/api';
+import { useSearchParams } from 'next/navigation';
+
+type Props = {
+  pagination: PaginationMeta;
+};
+
+export function WordbookPagination({ pagination }: Props) {
+  const searchParams = useSearchParams();
+  const { current_page: currentPage, total_pages: totalPages } = pagination;
+
+  if (totalPages <= 1) {
+    return null;
+  }
+
+  const buildHref = (page: number): string => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (page === 1) {
+      params.delete('page');
+    } else {
+      params.set('page', String(page));
+    }
+    const qs = params.toString();
+    return qs === '' ? '?' : `?${qs}`;
+  };
+
+  const pages = Array.from({ length: totalPages }, (_, i) => i + 1);
+  const isFirst = currentPage <= 1;
+  const isLast = currentPage >= totalPages;
+
+  return (
+    <Pagination className="mt-8">
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationPrevious
+            href={buildHref(Math.max(1, currentPage - 1))}
+            aria-disabled={isFirst}
+            tabIndex={isFirst ? -1 : undefined}
+            className={
+              isFirst ? 'pointer-events-none opacity-50' : undefined
+            }
+          />
+        </PaginationItem>
+        {pages.map((page) => (
+          <PaginationItem key={page}>
+            <PaginationLink
+              href={buildHref(page)}
+              isActive={page === currentPage}
+            >
+              {page}
+            </PaginationLink>
+          </PaginationItem>
+        ))}
+        <PaginationItem>
+          <PaginationNext
+            href={buildHref(Math.min(totalPages, currentPage + 1))}
+            aria-disabled={isLast}
+            tabIndex={isLast ? -1 : undefined}
+            className={
+              isLast ? 'pointer-events-none opacity-50' : undefined
+            }
+          />
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  );
+}


### PR DESCRIPTION
## Summary
- Wire the dashboard wordbook list to server-side pagination using the existing `PaginatedResponse<Wordbook>` envelope. Page is driven by the `?page` URL search param; `per_page` is fixed to 12.
- Add a `WordbookPagination` client component (Previous / numbered / Next) that preserves any other search params when navigating between pages and hides itself when there is only one page.
- Add the shadcn/ui `Pagination` primitive and adapt it to use `next/link` so page transitions stream through the existing `<Suspense>` boundary instead of doing full navigations.

## Test plan
- [x] `pnpm dev` and visit `/dashboard`; with >12 wordbooks, verify the first page shows 12 cards and the pager renders all page numbers.
- [x] Click a page link and confirm the URL updates to `?page=N`, the skeleton fallback shows briefly, and the new page renders.
- [x] Confirm `Previous` is disabled on page 1 and `Next` is disabled on the last page.
- [x] Visit `/dashboard?page=999` and confirm an empty-page message is shown along with the pager (no crash).
- [x] Visit `/dashboard?page=abc` and confirm it falls back to page 1.
- [x] Confirm the empty-state copy ("まだ単語帳がありません…") still shows when there are zero wordbooks on page 1.
- [x] `pnpm lint` and `pnpm build` pass.