### PR TITLE
Improve dashboard wordbook list skeleton

### DIFF
--- a/src/app/(authenticated)/dashboard/loading.tsx
+++ b/src/app/(authenticated)/dashboard/loading.tsx
@@ -1,4 +1,5 @@
 import { Skeleton } from '@/components/ui/skeleton';
+import { WordbookCardSkeleton } from '@/components/wordbook/wordbook-card-skeleton';
 
 export default function DashboardLoading() {
   return (
@@ -9,8 +10,8 @@ export default function DashboardLoading() {
           <Skeleton className="h-10 w-36" />
         </div>
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {Array.from({ length: 6 }).map((_, i) => (
-            <Skeleton key={i} className="h-24 rounded-lg" />
+          {Array.from({ length: 12 }).map((_, i) => (
+            <WordbookCardSkeleton key={i} />
           ))}
         </div>
       </div>

--- a/src/app/(authenticated)/dashboard/page.tsx
+++ b/src/app/(authenticated)/dashboard/page.tsx
@@ -1,6 +1,6 @@
 import { GuestMigrationBanner } from '@/components/auth/guest-migration-banner';
 import { Button } from '@/components/ui/button';
-import { Skeleton } from '@/components/ui/skeleton';
+import { WordbookCardSkeleton } from '@/components/wordbook/wordbook-card-skeleton';
 import { WordbookList } from '@/components/wordbook/wordbook-list';
 import { Plus } from 'lucide-react';
 import type { Metadata } from 'next';
@@ -47,8 +47,8 @@ export default async function DashboardPage({
           key={page}
           fallback={
             <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              {Array.from({ length: 6 }).map((_, i) => (
-                <Skeleton key={i} className="h-24 rounded-lg" />
+              {Array.from({ length: 12 }).map((_, i) => (
+                <WordbookCardSkeleton key={i} />
               ))}
             </div>
           }

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -4,7 +4,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="skeleton"
-      className={cn("animate-pulse rounded-md bg-accent", className)}
+      className={cn("animate-pulse rounded-md bg-muted", className)}
       {...props}
     />
   )

--- a/src/components/wordbook/wordbook-card-skeleton.tsx
+++ b/src/components/wordbook/wordbook-card-skeleton.tsx
@@ -1,0 +1,18 @@
+import { Card, CardHeader } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+
+export function WordbookCardSkeleton() {
+  return (
+    <Card className="h-full">
+      <CardHeader>
+        <div className="flex items-start gap-3">
+          <Skeleton className="h-9 w-9 rounded-md" />
+          <div className="flex-1 min-w-0 space-y-2">
+            <Skeleton className="h-5 w-3/4" />
+            <Skeleton className="h-4 w-1/3" />
+          </div>
+        </div>
+      </CardHeader>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary

- Switch the `Skeleton` default background from `bg-accent` to `bg-muted`. The project repurposes `--accent` as a saturated brand green (`oklch(0.72 0.15 145)`), which made loading placeholders far too eye-grabbing across the app.
- Add a `WordbookCardSkeleton` component that mirrors the real `WordbookCard` layout (icon square + title row + meta row inside a `Card`), so the loading state has the same shape, height, and border as the resolved cards — eliminating the layout shift from the previous flat-rectangle skeleton.
- Use `WordbookCardSkeleton` in both `dashboard/page.tsx` Suspense fallback and the route-level `dashboard/loading.tsx`, and bump the placeholder count from 6 to 12 to match `WordbookList`'s per-page size.

## Test plan

- [x] `pnpm lint` passes
- [x] Open `/dashboard` with throttled network and confirm the loading state shows soft-grey card skeletons (no green) that align 1:1 with the resolved card grid
- [x] Cross-check other Skeleton consumers (e.g. `/wordbooks/[wordbookId]`, settings, edit pages) still render acceptably with `bg-muted`