### PR TITLE
fix: replace reset with unstable_retry in error boundaries

### DIFF
--- a/src/app/(authenticated)/dashboard/error.tsx
+++ b/src/app/(authenticated)/dashboard/error.tsx
@@ -3,10 +3,10 @@
 import { Button } from '@/components/ui/button';
 
 export default function DashboardError({
-  reset,
+  unstable_retry,
 }: {
   error: Error & { digest?: string };
-  reset: () => void;
+  unstable_retry: () => void;
 }) {
   return (
     <div className="min-h-screen bg-background flex items-center justify-center">
@@ -15,7 +15,7 @@ export default function DashboardError({
         <p className="text-muted-foreground">
           データの読み込みに失敗しました
         </p>
-        <Button onClick={reset}>再試行</Button>
+        <Button onClick={unstable_retry}>再試行</Button>
       </div>
     </div>
   );

--- a/src/app/(authenticated)/wordbooks/[wordbookId]/error.tsx
+++ b/src/app/(authenticated)/wordbooks/[wordbookId]/error.tsx
@@ -3,10 +3,10 @@
 import { Button } from '@/components/ui/button';
 
 export default function WordbookError({
-  reset,
+  unstable_retry,
 }: {
   error: Error & { digest?: string };
-  reset: () => void;
+  unstable_retry: () => void;
 }) {
   return (
     <div className="min-h-screen bg-background flex items-center justify-center">
@@ -15,7 +15,7 @@ export default function WordbookError({
         <p className="text-muted-foreground">
           データの読み込みに失敗しました
         </p>
-        <Button onClick={reset}>再試行</Button>
+        <Button onClick={unstable_retry}>再試行</Button>
       </div>
     </div>
   );


### PR DESCRIPTION
Closes #76

Replace the `reset` prop with `unstable_retry` in both error boundaries (dashboard and wordbook detail). Unlike `reset`, `unstable_retry` re-runs the failed Server Component data fetching on the server, which matches the intent of these error boundaries that handle server-side fetch failures.

Generated with [Claude Code](https://claude.ai/code)