### PR TITLE
refactor(word): use nested attributes for word update

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -374,7 +374,19 @@ paths:
           $ref: "#/components/responses/NotFound"
     patch:
       tags: [Words]
-      summary: Update a word
+      summary: Update a word with optional nested meanings and examples
+      description: |
+        Updates a word. Optionally accepts nested `meanings_attributes`
+        (with `examples_attributes` inside each meaning) to update or create
+        related records in a single atomic transaction.
+
+        For each nested item, supplying `id` updates the existing record
+        (only the fields you include are changed); omitting `id` creates a
+        new record (all required fields must be provided).
+
+        Deletion is not supported through nested attributes — use the
+        dedicated `DELETE /meanings/{id}` and `DELETE /examples/{id}`
+        endpoints instead.
       security:
         - bearerAuth: []
       requestBody:
@@ -392,6 +404,40 @@ paths:
                       type: string
                     status:
                       $ref: "#/components/schemas/WordStatus"
+                    meanings_attributes:
+                      type: array
+                      description: |
+                        Nested meanings to update or create. Include `id` to update an
+                        existing meaning; omit `id` to create a new one.
+                      items:
+                        type: object
+                        properties:
+                          id:
+                            type: integer
+                            description: ID of the existing meaning to update. Omit when creating a new meaning.
+                          definition:
+                            type: string
+                          display_order:
+                            type: integer
+                            minimum: 1
+                          examples_attributes:
+                            type: array
+                            description: |
+                              Nested examples to update or create. Include `id` to update an
+                              existing example; omit `id` to create a new one.
+                            items:
+                              type: object
+                              properties:
+                                id:
+                                  type: integer
+                                  description: ID of the existing example to update. Omit when creating a new example.
+                                sentence:
+                                  type: string
+                                translation:
+                                  type: string
+                                display_order:
+                                  type: integer
+                                  minimum: 1
       responses:
         "200":
           description: Updated

--- a/src/lib/actions/word-actions.ts
+++ b/src/lib/actions/word-actions.ts
@@ -1,12 +1,12 @@
 'use server';
 
 import { ApiError } from '@/lib/api/client';
-import { createExample, updateExample } from '@/lib/api/examples';
-import { createMeaning, updateMeaning } from '@/lib/api/meanings';
 import { createWord, deleteWord, updateWord } from '@/lib/api/words';
 import type {
   CreateExampleNestedInput,
   CreateMeaningNestedInput,
+  UpdateExampleNestedInput,
+  UpdateMeaningNestedInput,
   WordStatus,
 } from '@/types/api';
 import { revalidatePath } from 'next/cache';
@@ -102,71 +102,67 @@ export async function updateWordAction(
     return { errors: ['単語が見つかりません'] };
   }
 
+  const trimmedMeaning =
+    typeof meaningContent === 'string' ? meaningContent.trim() : '';
+  const trimmedSentence =
+    typeof exampleSentence === 'string' ? exampleSentence.trim() : '';
+  const trimmedTranslation =
+    typeof exampleTranslation === 'string' ? exampleTranslation.trim() : '';
+  const numericMeaningId =
+    typeof meaningId === 'string' && meaningId !== ''
+      ? Number(meaningId)
+      : undefined;
+  const numericExampleId =
+    typeof exampleId === 'string' && exampleId !== ''
+      ? Number(exampleId)
+      : undefined;
+
+  let meanings_attributes: UpdateMeaningNestedInput[] | undefined;
+  if (trimmedMeaning !== '') {
+    let examples_attributes: UpdateExampleNestedInput[] | undefined;
+    if (trimmedSentence !== '' && trimmedTranslation !== '') {
+      examples_attributes =
+        numericExampleId !== undefined
+          ? [
+              {
+                id: numericExampleId,
+                sentence: trimmedSentence,
+                translation: trimmedTranslation,
+              },
+            ]
+          : [
+              {
+                sentence: trimmedSentence,
+                translation: trimmedTranslation,
+                display_order: 1,
+              },
+            ];
+    }
+
+    meanings_attributes =
+      numericMeaningId !== undefined
+        ? [
+            {
+              id: numericMeaningId,
+              definition: trimmedMeaning,
+              examples_attributes,
+            },
+          ]
+        : [
+            {
+              definition: trimmedMeaning,
+              display_order: 1,
+              examples_attributes,
+            },
+          ];
+  }
+
   try {
     await updateWord(Number(wordbookId), Number(wordId), {
       spelling: spelling.trim(),
       status: status ?? undefined,
+      meanings_attributes,
     });
-
-    let effectiveMeaningId: number | undefined =
-      typeof meaningId === 'string' && meaningId !== ''
-        ? Number(meaningId)
-        : undefined;
-
-    if (typeof meaningContent === 'string' && meaningContent.trim() !== '') {
-      if (effectiveMeaningId !== undefined) {
-        await updateMeaning(
-          Number(wordbookId),
-          Number(wordId),
-          effectiveMeaningId,
-          {
-            definition: meaningContent.trim(),
-          }
-        );
-      } else {
-        const createdMeaning = await createMeaning(
-          Number(wordbookId),
-          Number(wordId),
-          {
-            definition: meaningContent.trim(),
-            display_order: 1,
-          }
-        );
-        effectiveMeaningId = createdMeaning.id;
-      }
-    }
-
-    if (
-      effectiveMeaningId !== undefined &&
-      typeof exampleSentence === 'string' &&
-      exampleSentence.trim() !== '' &&
-      typeof exampleTranslation === 'string' &&
-      exampleTranslation.trim() !== ''
-    ) {
-      if (typeof exampleId === 'string' && exampleId !== '') {
-        await updateExample(
-          Number(wordbookId),
-          Number(wordId),
-          effectiveMeaningId,
-          Number(exampleId),
-          {
-            sentence: exampleSentence.trim(),
-            translation: exampleTranslation.trim(),
-          }
-        );
-      } else {
-        await createExample(
-          Number(wordbookId),
-          Number(wordId),
-          effectiveMeaningId,
-          {
-            sentence: exampleSentence.trim(),
-            translation: exampleTranslation.trim(),
-            display_order: 1,
-          }
-        );
-      }
-    }
 
     revalidatePath(`/wordbooks/${wordbookId}`);
     revalidatePath(`/wordbooks/${wordbookId}/test`);

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -98,9 +98,24 @@ export type CreateWordInput = {
   meanings_attributes?: CreateMeaningNestedInput[];
 };
 
+export type UpdateExampleNestedInput = {
+  id?: number;
+  sentence?: string;
+  translation?: string;
+  display_order?: number;
+};
+
+export type UpdateMeaningNestedInput = {
+  id?: number;
+  definition?: string;
+  display_order?: number;
+  examples_attributes?: UpdateExampleNestedInput[];
+};
+
 export type UpdateWordInput = {
   spelling?: string;
   status?: WordStatus;
+  meanings_attributes?: UpdateMeaningNestedInput[];
 };
 
 export type CreateMeaningInput = {


### PR DESCRIPTION
## Summary
- Collapse the 3 sequential API calls in `updateWordAction` (word PATCH → meaning PATCH/POST → example PATCH/POST) into a single PATCH that uses the backend's new `meanings_attributes` / `examples_attributes` payload, restoring atomicity and matching the create flow.
- Extend `UpdateWordInput` with nested `UpdateMeaningNestedInput` / `UpdateExampleNestedInput` types (id present = update, omitted = create — deletion still goes through the dedicated endpoints per spec).
- Bring `docs/openapi.yaml` in line with the backend by documenting the nested update on `PATCH /wordbooks/{id}/words/{id}`.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] Manual verification with playwright-cli + Rails dev log inspection:
  - **Full update**: spelling / definition / sentence / translation all changed → single PATCH with `meanings_attributes:[{id,...,examples_attributes:[{id,...}]}]`, detail page reflects all changes.
  - **Spelling only**: only spelling changed → single PATCH, meaning/example untouched.
  - **No prior meaning**: word with no meaning gets meaning + example via edit → nested payload has no `id` (creation), records persisted.
  - **Example translation cleared**: existing-example word with translation emptied → request omits `examples_attributes`, existing example preserved (existing skip behavior maintained).