### PR TITLE
fix: replace FlaskConical with Layers icon on テスト開始 button

### DIFF
--- a/src/app/(authenticated)/wordbooks/[wordbookId]/wordbook-detail-content.tsx
+++ b/src/app/(authenticated)/wordbooks/[wordbookId]/wordbook-detail-content.tsx
@@ -5,7 +5,7 @@ import { WordList } from '@/components/word/word-list';
 import { WordbookDeleteDialog } from '@/components/wordbook/wordbook-delete-dialog';
 import { getWordbook } from '@/lib/api/wordbooks';
 import type { WordStatus } from '@/types/api';
-import { Edit, FlaskConical, Plus } from 'lucide-react';
+import { Edit, Layers, Plus } from 'lucide-react';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { Suspense } from 'react';
@@ -55,7 +55,7 @@ export async function WordbookDetailContent({
         </Button>
         <Button asChild variant="secondary">
           <Link href={`/wordbooks/${wordbook.id}/test`}>
-            <FlaskConical className="mr-2 h-4 w-4" />
+            <Layers className="mr-2 h-4 w-4" />
             テスト開始
           </Link>
         </Button>


### PR DESCRIPTION
Replace `FlaskConical` with `Layers` icon on the "テスト開始" button in the wordbook detail page.

`Layers` more accurately represents a stack of flashcards, which aligns with the SRS review session this button starts.

Closes #82

Generated with [Claude Code](https://claude.ai/code)