### PR TITLE
feat: adopt Inter + Noto Sans JP via next/font/google

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -77,7 +77,9 @@
 }
 
 @theme inline {
-  --font-sans: 'Geist', 'Geist Fallback';
+  --font-sans: var(--font-sans), var(--font-sans-jp), ui-sans-serif, system-ui,
+    sans-serif;
+  --font-sans-jp: var(--font-sans-jp);
   --font-mono: 'Geist Mono', 'Geist Mono Fallback';
   --color-background: var(--background);
   --color-foreground: var(--foreground);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,20 @@
 import { Header } from '@/components/layout/header';
 import { Toaster } from '@/components/ui/sonner';
 import type { Metadata } from 'next';
+import { Inter, Noto_Sans_JP } from 'next/font/google';
 import './globals.css';
+
+const inter = Inter({
+  variable: '--font-sans',
+  subsets: ['latin'],
+  display: 'swap',
+});
+
+const notoSansJP = Noto_Sans_JP({
+  variable: '--font-sans-jp',
+  weight: ['400', '500', '700'],
+  display: 'swap',
+});
 
 export const metadata: Metadata = {
   title: 'WordBeetle',
@@ -17,8 +30,8 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="ja">
-      <body className={`font-sans antialiased`}>
+    <html lang="ja" className={`${inter.variable} ${notoSansJP.variable}`}>
+      <body className="font-sans antialiased">
         <Header />
         {children}
         <Toaster />


### PR DESCRIPTION
Closes #59

## Changes

- Load Inter and Noto Sans JP using `next/font/google` in `layout.tsx`
- Wire `--font-sans` and `--font-sans-jp` CSS variables into Tailwind v4 `@theme`
- Remove hardcoded 'Geist' / 'Geist Fallback' references

Generated with [Claude Code](https://claude.ai/code)