### PR TITLE
feat: add user account deletion (withdrawal)

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -906,8 +906,8 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
-  # ──────────────── User (singular resource) ────────────────
-  /api/v1/user:
+  # ──────────────── Current User ────────────────
+  /api/v1/users/me:
     delete:
       tags: [Users]
       summary: Delete the current user account

--- a/src/app/(authenticated)/settings/page.tsx
+++ b/src/app/(authenticated)/settings/page.tsx
@@ -1,3 +1,5 @@
+import { AccountDeletionCard } from '@/components/settings/account-deletion-card';
+import { SettingsForm } from '@/components/settings/settings-form';
 import {
   Card,
   CardContent,
@@ -6,7 +8,7 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
-import { SettingsForm } from '@/components/settings/settings-form';
+import { verifySession } from '@/lib/dal/session';
 import { getSettingView } from '@/lib/dto/setting';
 import type { Metadata } from 'next';
 import { Suspense } from 'react';
@@ -17,19 +19,23 @@ export const metadata: Metadata = {
 
 async function SettingsContent() {
   const setting = (await getSettingView()) ?? undefined;
+  const { isGuest } = await verifySession();
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>復習間隔</CardTitle>
-        <CardDescription>
-          テストの自己評価に応じた復習間隔を設定します
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        <SettingsForm setting={setting} />
-      </CardContent>
-    </Card>
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>復習間隔</CardTitle>
+          <CardDescription>
+            テストの自己評価に応じた復習間隔を設定します
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <SettingsForm setting={setting} />
+        </CardContent>
+      </Card>
+      {!isGuest && <AccountDeletionCard />}
+    </div>
   );
 }
 

--- a/src/components/settings/account-deletion-card.tsx
+++ b/src/components/settings/account-deletion-card.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { deleteAccountAction } from '@/lib/actions/user-actions';
+import { Trash2 } from 'lucide-react';
+import { useTransition } from 'react';
+import { toast } from 'sonner';
+
+export function AccountDeletionCard() {
+  const [isPending, startTransition] = useTransition();
+
+  function handleDelete() {
+    startTransition(async () => {
+      const result = await deleteAccountAction();
+
+      if (result?.errors !== undefined && result.errors.length > 0) {
+        toast.error(result.errors[0]);
+      }
+    });
+  }
+
+  return (
+    <Card className="border-destructive/50">
+      <CardHeader>
+        <CardTitle className="text-destructive">アカウント削除</CardTitle>
+        <CardDescription>
+          アカウントを削除すると、すべての単語帳・単語・設定が完全に削除され、復元できません。
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <Button variant="destructive">
+              <Trash2 className="mr-2 h-4 w-4" />
+              アカウントを削除
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>
+                本当にアカウントを削除しますか？
+              </AlertDialogTitle>
+              <AlertDialogDescription>
+                すべてのデータが完全に削除され、この操作は取り消せません。
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>キャンセル</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={handleDelete}
+                disabled={isPending}
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              >
+                {isPending ? '削除中...' : '削除する'}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/actions/user-actions.ts
+++ b/src/lib/actions/user-actions.ts
@@ -1,0 +1,20 @@
+'use server';
+
+import { signOut } from '@/lib/auth';
+import { ApiError } from '@/lib/dal/client';
+import { deleteCurrentUser } from '@/lib/dal/user';
+
+export type DeleteAccountResult = { errors: string[] } | undefined;
+
+export async function deleteAccountAction(): Promise<DeleteAccountResult> {
+  try {
+    await deleteCurrentUser();
+  } catch (error) {
+    if (error instanceof ApiError) {
+      return { errors: ['アカウントの削除に失敗しました'] };
+    }
+    throw error;
+  }
+
+  await signOut({ redirectTo: '/auth' });
+}

--- a/src/lib/dal/user.ts
+++ b/src/lib/dal/user.ts
@@ -1,0 +1,7 @@
+import 'server-only';
+
+import { apiRequest } from './client';
+
+export async function deleteCurrentUser(): Promise<void> {
+  await apiRequest<void>({ method: 'DELETE', path: '/users/me' });
+}


### PR DESCRIPTION
## Summary

- Add account deletion (withdrawal) feature for OAuth users
- New DAL `deleteCurrentUser()` calls `DELETE /users/me`
- New server action `deleteAccountAction` deletes the account then signs the user out and redirects to `/auth`
- New `AccountDeletionCard` on the settings page (hidden for guest users, who have no persistent account to delete)

## Test plan

- [x] Sign in as an OAuth user and visit `/settings` — verify the destructive "アカウント削除" card appears at the bottom
- [x] Sign in as a guest and visit `/settings` — verify the deletion card does NOT appear
- [x] Click "アカウントを削除" → confirm the AlertDialog appears, then click "削除する"
- [x] After deletion, verify the user is redirected to `/auth` and a fresh sign-in does not restore the previous data
- [x] Simulate an API failure (e.g., stop the backend) and confirm an error toast appears
- [x] `pnpm lint` and `pnpm build` pass