### PR TITLE
feat: support multiple meanings per word

### DIFF
--- a/src/app/(authenticated)/wordbooks/[wordbookId]/words/[wordId]/edit/page.tsx
+++ b/src/app/(authenticated)/wordbooks/[wordbookId]/words/[wordId]/edit/page.tsx
@@ -33,16 +33,14 @@ async function EditWordContent({
     notFound();
   }
 
-  const sortedMeanings = [...word.meanings].sort(
-    (a, b) => a.display_order - b.display_order,
-  );
-  const firstMeaning = sortedMeanings[0];
-  const firstExample =
-    firstMeaning !== undefined
-      ? [...firstMeaning.examples].sort(
-          (a, b) => a.display_order - b.display_order,
-        )[0]
-      : undefined;
+  const sortedMeanings = [...word.meanings]
+    .sort((a, b) => a.display_order - b.display_order)
+    .map((m) => ({
+      ...m,
+      examples: [...m.examples].sort(
+        (a, b) => a.display_order - b.display_order,
+      ),
+    }));
 
   return (
     <Card>
@@ -53,8 +51,7 @@ async function EditWordContent({
         <WordForm
           wordbookId={Number(wordbookId)}
           word={word}
-          meaning={firstMeaning}
-          example={firstExample}
+          meanings={sortedMeanings}
         />
       </CardContent>
     </Card>

--- a/src/components/word/word-form.tsx
+++ b/src/components/word/word-form.tsx
@@ -94,11 +94,14 @@ export function WordForm({
   };
 
   const removeMeaning = (rowKey: string) => {
+    const target = rows.find((m) => m.rowKey === rowKey);
+    if (target?.id !== undefined) {
+      const removedId = target.id;
+      setRemovedMeaningIds((ids) =>
+        ids.includes(removedId) ? ids : [...ids, removedId]
+      );
+    }
     setRows((prev) => {
-      const target = prev.find((m) => m.rowKey === rowKey);
-      if (target?.id !== undefined) {
-        setRemovedMeaningIds((ids) => [...ids, target.id as number]);
-      }
       const next = prev.filter((m) => m.rowKey !== rowKey);
       return next.length === 0
         ? [{ rowKey: nextKey('new-m'), definition: '', examples: [] }]
@@ -117,21 +120,27 @@ export function WordForm({
   };
 
   const removeExample = (meaningRowKey: string, exampleRowKey: string) => {
+    const meaning = rows.find((m) => m.rowKey === meaningRowKey);
+    const target = meaning?.examples.find((e) => e.rowKey === exampleRowKey);
+    if (
+      target?.id !== undefined &&
+      meaning !== undefined &&
+      meaning.id !== undefined
+    ) {
+      const ref = `${meaning.id}:${target.id}`;
+      setRemovedExampleRefs((refs) =>
+        refs.includes(ref) ? refs : [...refs, ref]
+      );
+    }
     setRows((prev) =>
-      prev.map((m) => {
-        if (m.rowKey !== meaningRowKey) return m;
-        const target = m.examples.find((e) => e.rowKey === exampleRowKey);
-        if (target?.id !== undefined && m.id !== undefined) {
-          setRemovedExampleRefs((refs) => [
-            ...refs,
-            `${m.id as number}:${target.id as number}`,
-          ]);
-        }
-        return {
-          ...m,
-          examples: m.examples.filter((e) => e.rowKey !== exampleRowKey),
-        };
-      })
+      prev.map((m) =>
+        m.rowKey === meaningRowKey
+          ? {
+              ...m,
+              examples: m.examples.filter((e) => e.rowKey !== exampleRowKey),
+            }
+          : m
+      )
     );
   };
 

--- a/src/components/word/word-form.tsx
+++ b/src/components/word/word-form.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { AudioPlayButton } from '@/components/audio/audio-play-button';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -9,20 +10,54 @@ import {
   createWordAction,
   updateWordAction,
 } from '@/lib/actions/word-actions';
-import type { ExampleView } from '@/lib/dto/example';
 import type { MeaningView } from '@/lib/dto/meaning';
 import type { WordView } from '@/lib/dto/word';
-import { useActionState } from 'react';
-import { AudioPlayButton } from '@/components/audio/audio-play-button';
+import { useActionState, useRef, useState } from 'react';
+
+const MAX_EXAMPLES_PER_MEANING = 2;
+
+type ExampleRow = {
+  rowKey: string;
+  id?: number;
+  sentence: string;
+  translation: string;
+};
+
+type MeaningRow = {
+  rowKey: string;
+  id?: number;
+  definition: string;
+  examples: ExampleRow[];
+};
 
 type WordFormProps = {
   wordbookId: number;
   word?: WordView;
-  meaning?: MeaningView;
-  example?: ExampleView;
+  meanings?: MeaningView[];
 };
 
-export function WordForm({ wordbookId, word, meaning, example }: WordFormProps) {
+function buildInitialRows(meanings: MeaningView[]): MeaningRow[] {
+  if (meanings.length === 0) {
+    return [{ rowKey: 'new-0', definition: '', examples: [] }];
+  }
+  return meanings.map((m) => ({
+    rowKey: `existing-m-${m.id}`,
+    id: m.id,
+    definition: m.definition,
+    examples: m.examples.map((e) => ({
+      rowKey: `existing-e-${e.id}`,
+      id: e.id,
+      sentence: e.sentence,
+      translation: e.translation,
+    })),
+  }));
+}
+
+export function WordForm({
+  wordbookId,
+  word,
+  meanings = [],
+}: WordFormProps) {
   const isEditing = word !== undefined;
   const action = isEditing ? updateWordAction : createWordAction;
   const [state, formAction, isPending] = useActionState<
@@ -30,19 +65,99 @@ export function WordForm({ wordbookId, word, meaning, example }: WordFormProps) 
     FormData
   >(action, {});
 
+  const [rows, setRows] = useState<MeaningRow[]>(() =>
+    buildInitialRows(meanings)
+  );
+  const [removedMeaningIds, setRemovedMeaningIds] = useState<number[]>([]);
+  const [removedExampleRefs, setRemovedExampleRefs] = useState<string[]>([]);
+
+  const counterRef = useRef(0);
+  const nextKey = (prefix: string) => {
+    counterRef.current += 1;
+    return `${prefix}-${counterRef.current}`;
+  };
+
+  const updateMeaningRow = (
+    rowKey: string,
+    updater: (m: MeaningRow) => MeaningRow
+  ) => {
+    setRows((prev) =>
+      prev.map((m) => (m.rowKey === rowKey ? updater(m) : m))
+    );
+  };
+
+  const addMeaning = () => {
+    setRows((prev) => [
+      ...prev,
+      { rowKey: nextKey('new-m'), definition: '', examples: [] },
+    ]);
+  };
+
+  const removeMeaning = (rowKey: string) => {
+    setRows((prev) => {
+      const target = prev.find((m) => m.rowKey === rowKey);
+      if (target?.id !== undefined) {
+        setRemovedMeaningIds((ids) => [...ids, target.id as number]);
+      }
+      const next = prev.filter((m) => m.rowKey !== rowKey);
+      return next.length === 0
+        ? [{ rowKey: nextKey('new-m'), definition: '', examples: [] }]
+        : next;
+    });
+  };
+
+  const addExample = (meaningRowKey: string) => {
+    updateMeaningRow(meaningRowKey, (m) => ({
+      ...m,
+      examples: [
+        ...m.examples,
+        { rowKey: nextKey('new-e'), sentence: '', translation: '' },
+      ],
+    }));
+  };
+
+  const removeExample = (meaningRowKey: string, exampleRowKey: string) => {
+    setRows((prev) =>
+      prev.map((m) => {
+        if (m.rowKey !== meaningRowKey) return m;
+        const target = m.examples.find((e) => e.rowKey === exampleRowKey);
+        if (target?.id !== undefined && m.id !== undefined) {
+          setRemovedExampleRefs((refs) => [
+            ...refs,
+            `${m.id as number}:${target.id as number}`,
+          ]);
+        }
+        return {
+          ...m,
+          examples: m.examples.filter((e) => e.rowKey !== exampleRowKey),
+        };
+      })
+    );
+  };
+
   return (
     <form action={formAction} className="space-y-6">
       <input type="hidden" name="wordbookId" value={wordbookId} />
       {isEditing && (
         <>
           <input type="hidden" name="wordId" value={word.id} />
-          {meaning !== undefined && (
-            <input type="hidden" name="meaningId" value={meaning.id} />
-          )}
-          {example !== undefined && (
-            <input type="hidden" name="exampleId" value={example.id} />
-          )}
           <input type="hidden" name="status" value={word.status} />
+          {removedMeaningIds.map((id) => (
+            <input
+              key={`rm-m-${id}`}
+              type="hidden"
+              name="removedMeaningIds"
+              value={id}
+            />
+          ))}
+          {removedExampleRefs.map((ref) => (
+            <input
+              key={`rm-e-${ref}`}
+              type="hidden"
+              name="removedExampleRefs"
+              value={ref}
+            />
+          ))}
         </>
       )}
 
@@ -60,36 +175,138 @@ export function WordForm({ wordbookId, word, meaning, example }: WordFormProps) 
         />
       </div>
 
-      <div className="space-y-2">
-        <Label htmlFor="meaning">意味</Label>
-        <Input
-          id="meaning"
-          name="meaning"
-          defaultValue={meaning?.definition ?? ''}
-          placeholder="例: りんご"
-        />
-      </div>
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <Label>意味</Label>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={addMeaning}
+          >
+            意味を追加
+          </Button>
+        </div>
 
-      <div className="space-y-2">
-        <Label htmlFor="exampleSentence">例文</Label>
-        <Textarea
-          id="exampleSentence"
-          name="exampleSentence"
-          defaultValue={example?.sentence ?? ''}
-          placeholder="例: I ate an apple."
-          rows={2}
-        />
-      </div>
+        <ul className="space-y-4">
+          {rows.map((m, i) => (
+            <li
+              key={m.rowKey}
+              className="space-y-3 rounded-md border p-4"
+            >
+              {m.id !== undefined && (
+                <input
+                  type="hidden"
+                  name={`meanings[${i}][id]`}
+                  value={m.id}
+                />
+              )}
 
-      <div className="space-y-2">
-        <Label htmlFor="exampleTranslation">例文の訳</Label>
-        <Textarea
-          id="exampleTranslation"
-          name="exampleTranslation"
-          defaultValue={example?.translation ?? ''}
-          placeholder="例: 私はりんごを食べた。"
-          rows={2}
-        />
+              <div className="flex items-start gap-2">
+                <div className="flex-1 space-y-2">
+                  <Label htmlFor={`meaning-def-${m.rowKey}`}>
+                    意味 {i + 1}
+                  </Label>
+                  <Input
+                    id={`meaning-def-${m.rowKey}`}
+                    name={`meanings[${i}][definition]`}
+                    value={m.definition}
+                    onChange={(e) =>
+                      updateMeaningRow(m.rowKey, (mm) => ({
+                        ...mm,
+                        definition: e.target.value,
+                      }))
+                    }
+                    placeholder="例: りんご"
+                  />
+                </div>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => removeMeaning(m.rowKey)}
+                  className="mt-7"
+                >
+                  削除
+                </Button>
+              </div>
+
+              <div className="space-y-3 pl-2">
+                {m.examples.map((ex, j) => (
+                  <div
+                    key={ex.rowKey}
+                    className="space-y-2 rounded-md border border-dashed p-3"
+                  >
+                    {ex.id !== undefined && (
+                      <input
+                        type="hidden"
+                        name={`meanings[${i}][examples][${j}][id]`}
+                        value={ex.id}
+                      />
+                    )}
+                    <div className="flex items-center justify-between">
+                      <Label htmlFor={`ex-sent-${ex.rowKey}`}>
+                        例文 {j + 1}
+                      </Label>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => removeExample(m.rowKey, ex.rowKey)}
+                      >
+                        削除
+                      </Button>
+                    </div>
+                    <Textarea
+                      id={`ex-sent-${ex.rowKey}`}
+                      name={`meanings[${i}][examples][${j}][sentence]`}
+                      value={ex.sentence}
+                      onChange={(e) =>
+                        updateMeaningRow(m.rowKey, (mm) => ({
+                          ...mm,
+                          examples: mm.examples.map((eee) =>
+                            eee.rowKey === ex.rowKey
+                              ? { ...eee, sentence: e.target.value }
+                              : eee
+                          ),
+                        }))
+                      }
+                      placeholder="例: I ate an apple."
+                      rows={2}
+                    />
+                    <Textarea
+                      id={`ex-trans-${ex.rowKey}`}
+                      name={`meanings[${i}][examples][${j}][translation]`}
+                      value={ex.translation}
+                      onChange={(e) =>
+                        updateMeaningRow(m.rowKey, (mm) => ({
+                          ...mm,
+                          examples: mm.examples.map((eee) =>
+                            eee.rowKey === ex.rowKey
+                              ? { ...eee, translation: e.target.value }
+                              : eee
+                          ),
+                        }))
+                      }
+                      placeholder="例: 私はりんごを食べた。"
+                      rows={2}
+                    />
+                  </div>
+                ))}
+                {m.examples.length < MAX_EXAMPLES_PER_MEANING && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => addExample(m.rowKey)}
+                  >
+                    例文を追加
+                  </Button>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
       </div>
 
       {state.errors !== undefined && state.errors.length > 0 && (
@@ -102,11 +319,7 @@ export function WordForm({ wordbookId, word, meaning, example }: WordFormProps) 
 
       <div className="flex gap-3">
         <Button type="submit" disabled={isPending}>
-          {isPending
-            ? '保存中...'
-            : isEditing
-              ? '更新する'
-              : '登録する'}
+          {isPending ? '保存中...' : isEditing ? '更新する' : '登録する'}
         </Button>
       </div>
     </form>

--- a/src/lib/actions/word-actions.ts
+++ b/src/lib/actions/word-actions.ts
@@ -1,6 +1,8 @@
 'use server';
 
 import { ApiError } from '@/lib/dal/client';
+import { deleteExample } from '@/lib/dal/examples';
+import { deleteMeaning } from '@/lib/dal/meanings';
 import { createWord, deleteWord, updateWord } from '@/lib/dal/words';
 import type {
   CreateExampleNestedInput,
@@ -16,15 +18,203 @@ export type WordActionState = {
   errors?: string[];
 };
 
+type ParsedExample = {
+  id?: number;
+  sentence: string;
+  translation: string;
+};
+
+type ParsedMeaning = {
+  id?: number;
+  definition: string;
+  examples: ParsedExample[];
+};
+
+const MEANING_FIELD_REGEX = /^meanings\[(\d+)\]\[(id|definition)\]$/;
+const EXAMPLE_FIELD_REGEX =
+  /^meanings\[(\d+)\]\[examples\]\[(\d+)\]\[(id|sentence|translation)\]$/;
+
+function parseMeaningsFromFormData(formData: FormData): ParsedMeaning[] {
+  const meaningBucket = new Map<
+    number,
+    { id?: number; definition: string }
+  >();
+  const exampleBucket = new Map<number, Map<number, ParsedExample>>();
+
+  const ensureMeaning = (i: number) => {
+    let bucket = meaningBucket.get(i);
+    if (bucket === undefined) {
+      bucket = { definition: '' };
+      meaningBucket.set(i, bucket);
+    }
+    return bucket;
+  };
+
+  const ensureExample = (mi: number, ei: number) => {
+    let inner = exampleBucket.get(mi);
+    if (inner === undefined) {
+      inner = new Map();
+      exampleBucket.set(mi, inner);
+    }
+    let ex = inner.get(ei);
+    if (ex === undefined) {
+      ex = { sentence: '', translation: '' };
+      inner.set(ei, ex);
+    }
+    return ex;
+  };
+
+  for (const [key, value] of formData.entries()) {
+    if (typeof value !== 'string') continue;
+
+    const mMatch = MEANING_FIELD_REGEX.exec(key);
+    if (mMatch !== null) {
+      const idx = Number(mMatch[1]);
+      const field = mMatch[2];
+      const meaning = ensureMeaning(idx);
+      if (field === 'id') {
+        const n = Number(value);
+        if (!Number.isNaN(n)) meaning.id = n;
+      } else {
+        meaning.definition = value.trim();
+      }
+      continue;
+    }
+
+    const eMatch = EXAMPLE_FIELD_REGEX.exec(key);
+    if (eMatch !== null) {
+      const mi = Number(eMatch[1]);
+      const ei = Number(eMatch[2]);
+      const field = eMatch[3];
+      ensureMeaning(mi);
+      const example = ensureExample(mi, ei);
+      if (field === 'id') {
+        const n = Number(value);
+        if (!Number.isNaN(n)) example.id = n;
+      } else if (field === 'sentence') {
+        example.sentence = value.trim();
+      } else {
+        example.translation = value.trim();
+      }
+    }
+  }
+
+  return [...meaningBucket.entries()]
+    .sort(([a], [b]) => a - b)
+    .map(([i, m]) => {
+      const examples = exampleBucket.get(i);
+      const exampleList: ParsedExample[] =
+        examples === undefined
+          ? []
+          : [...examples.entries()]
+              .sort(([a], [b]) => a - b)
+              .map(([, e]) => e);
+      return { ...m, examples: exampleList };
+    });
+}
+
+function buildCreateMeaningsAttributes(
+  parsed: ParsedMeaning[]
+): CreateMeaningNestedInput[] | undefined {
+  const result: CreateMeaningNestedInput[] = [];
+  let meaningOrder = 1;
+  for (const m of parsed) {
+    if (m.definition === '') continue;
+    const examples: CreateExampleNestedInput[] = [];
+    let exampleOrder = 1;
+    for (const e of m.examples) {
+      if (e.sentence === '' || e.translation === '') continue;
+      examples.push({
+        sentence: e.sentence,
+        translation: e.translation,
+        display_order: exampleOrder,
+      });
+      exampleOrder += 1;
+    }
+    result.push({
+      definition: m.definition,
+      display_order: meaningOrder,
+      examples_attributes: examples.length === 0 ? undefined : examples,
+    });
+    meaningOrder += 1;
+  }
+  return result.length === 0 ? undefined : result;
+}
+
+function buildUpdateMeaningsAttributes(
+  parsed: ParsedMeaning[]
+): UpdateMeaningNestedInput[] | undefined {
+  const result: UpdateMeaningNestedInput[] = [];
+  let meaningOrder = 1;
+  for (const m of parsed) {
+    if (m.definition === '') continue;
+    const examples: UpdateExampleNestedInput[] = [];
+    let exampleOrder = 1;
+    for (const e of m.examples) {
+      if (e.sentence === '' || e.translation === '') continue;
+      examples.push(
+        e.id !== undefined
+          ? {
+              id: e.id,
+              sentence: e.sentence,
+              translation: e.translation,
+              display_order: exampleOrder,
+            }
+          : {
+              sentence: e.sentence,
+              translation: e.translation,
+              display_order: exampleOrder,
+            }
+      );
+      exampleOrder += 1;
+    }
+    const examplesAttr = examples.length === 0 ? undefined : examples;
+    result.push(
+      m.id !== undefined
+        ? {
+            id: m.id,
+            definition: m.definition,
+            display_order: meaningOrder,
+            examples_attributes: examplesAttr,
+          }
+        : {
+            definition: m.definition,
+            display_order: meaningOrder,
+            examples_attributes: examplesAttr,
+          }
+    );
+    meaningOrder += 1;
+  }
+  return result.length === 0 ? undefined : result;
+}
+
+function parseRemovedMeaningIds(formData: FormData): number[] {
+  return formData
+    .getAll('removedMeaningIds')
+    .filter((v): v is string => typeof v === 'string')
+    .map((v) => Number(v))
+    .filter((n) => !Number.isNaN(n));
+}
+
+function parseRemovedExampleRefs(
+  formData: FormData
+): Array<{ meaningId: number; exampleId: number }> {
+  return formData
+    .getAll('removedExampleRefs')
+    .filter((v): v is string => typeof v === 'string')
+    .map((v) => {
+      const [miStr, eiStr] = v.split(':');
+      return { meaningId: Number(miStr), exampleId: Number(eiStr) };
+    })
+    .filter((r) => !Number.isNaN(r.meaningId) && !Number.isNaN(r.exampleId));
+}
+
 export async function createWordAction(
   _prevState: WordActionState,
   formData: FormData
 ): Promise<WordActionState> {
   const wordbookId = formData.get('wordbookId');
   const spelling = formData.get('spelling');
-  const meaningContent = formData.get('meaning');
-  const exampleSentence = formData.get('exampleSentence');
-  const exampleTranslation = formData.get('exampleTranslation');
 
   if (typeof spelling !== 'string' || spelling.trim() === '') {
     return { errors: ['スペルを入力してください'] };
@@ -34,33 +224,8 @@ export async function createWordAction(
     return { errors: ['単語帳が見つかりません'] };
   }
 
-  const trimmedMeaning =
-    typeof meaningContent === 'string' ? meaningContent.trim() : '';
-  const trimmedSentence =
-    typeof exampleSentence === 'string' ? exampleSentence.trim() : '';
-  const trimmedTranslation =
-    typeof exampleTranslation === 'string' ? exampleTranslation.trim() : '';
-
-  let meanings_attributes: CreateMeaningNestedInput[] | undefined;
-  if (trimmedMeaning !== '') {
-    let examples_attributes: CreateExampleNestedInput[] | undefined;
-    if (trimmedSentence !== '' && trimmedTranslation !== '') {
-      examples_attributes = [
-        {
-          sentence: trimmedSentence,
-          translation: trimmedTranslation,
-          display_order: 1,
-        },
-      ];
-    }
-    meanings_attributes = [
-      {
-        definition: trimmedMeaning,
-        display_order: 1,
-        examples_attributes,
-      },
-    ];
-  }
+  const parsed = parseMeaningsFromFormData(formData);
+  const meanings_attributes = buildCreateMeaningsAttributes(parsed);
 
   try {
     await createWord(Number(wordbookId), {
@@ -88,11 +253,6 @@ export async function updateWordAction(
   const wordbookId = formData.get('wordbookId');
   const spelling = formData.get('spelling');
   const status = formData.get('status') as WordStatus | null;
-  const meaningId = formData.get('meaningId');
-  const meaningContent = formData.get('meaning');
-  const exampleId = formData.get('exampleId');
-  const exampleSentence = formData.get('exampleSentence');
-  const exampleTranslation = formData.get('exampleTranslation');
 
   if (typeof spelling !== 'string' || spelling.trim() === '') {
     return { errors: ['スペルを入力してください'] };
@@ -102,60 +262,11 @@ export async function updateWordAction(
     return { errors: ['単語が見つかりません'] };
   }
 
-  const trimmedMeaning =
-    typeof meaningContent === 'string' ? meaningContent.trim() : '';
-  const trimmedSentence =
-    typeof exampleSentence === 'string' ? exampleSentence.trim() : '';
-  const trimmedTranslation =
-    typeof exampleTranslation === 'string' ? exampleTranslation.trim() : '';
-  const numericMeaningId =
-    typeof meaningId === 'string' && meaningId !== ''
-      ? Number(meaningId)
-      : undefined;
-  const numericExampleId =
-    typeof exampleId === 'string' && exampleId !== ''
-      ? Number(exampleId)
-      : undefined;
+  const parsed = parseMeaningsFromFormData(formData);
+  const meanings_attributes = buildUpdateMeaningsAttributes(parsed);
 
-  let meanings_attributes: UpdateMeaningNestedInput[] | undefined;
-  if (trimmedMeaning !== '') {
-    let examples_attributes: UpdateExampleNestedInput[] | undefined;
-    if (trimmedSentence !== '' && trimmedTranslation !== '') {
-      examples_attributes =
-        numericExampleId !== undefined
-          ? [
-              {
-                id: numericExampleId,
-                sentence: trimmedSentence,
-                translation: trimmedTranslation,
-              },
-            ]
-          : [
-              {
-                sentence: trimmedSentence,
-                translation: trimmedTranslation,
-                display_order: 1,
-              },
-            ];
-    }
-
-    meanings_attributes =
-      numericMeaningId !== undefined
-        ? [
-            {
-              id: numericMeaningId,
-              definition: trimmedMeaning,
-              examples_attributes,
-            },
-          ]
-        : [
-            {
-              definition: trimmedMeaning,
-              display_order: 1,
-              examples_attributes,
-            },
-          ];
-  }
+  const removedMeaningIds = parseRemovedMeaningIds(formData);
+  const removedExampleRefs = parseRemovedExampleRefs(formData);
 
   try {
     await updateWord(Number(wordbookId), Number(wordId), {
@@ -163,6 +274,20 @@ export async function updateWordAction(
       status: status ?? undefined,
       meanings_attributes,
     });
+
+    const meaningIdsToDelete = new Set(removedMeaningIds);
+    for (const { meaningId, exampleId } of removedExampleRefs) {
+      if (meaningIdsToDelete.has(meaningId)) continue;
+      await deleteExample(
+        Number(wordbookId),
+        Number(wordId),
+        meaningId,
+        exampleId
+      );
+    }
+    for (const meaningId of removedMeaningIds) {
+      await deleteMeaning(Number(wordbookId), Number(wordId), meaningId);
+    }
 
     revalidatePath(`/wordbooks/${wordbookId}`);
     revalidatePath(`/wordbooks/${wordbookId}/test`);


### PR DESCRIPTION
## Summary

- Replace the single-meaning + single-example word form with a dynamic form that lets users register, edit, and delete multiple meanings per word, each with up to 2 example sentences.
- Reuse the existing `meanings_attributes` nested API: parse indexed `FormData` (`meanings[i][definition]`, `meanings[i][examples][j][sentence]` …) on the server and build `Create/UpdateMeaningNestedInput[]` payloads.
- For removals on the edit form, collect existing record ids in hidden inputs (`removedMeaningIds`, `removedExampleRefs`) and fire `DELETE /meanings/:id` / `DELETE /examples/:id` after the update succeeds, since nested attributes do not support deletion.
- The detail view, DTO, DAL, and API types already supported multiple meanings — only the form UI and server actions needed work.

## Test plan

- [x] Create a word with 2 meanings and 2 examples on the first meaning; verify the detail page shows all entries
- [x] Edit the word: tweak meaning 1's definition, delete example 2, delete meaning 2, add a new meaning; verify the detail page reflects every change and removed records are gone via API
- [x] Confirm the per-meaning "例文を追加" button disappears once 2 examples are present
- [x] `pnpm lint`
- [x] `pnpm build`