### PR TITLE
feat: polish word form UI (1 example per meaning, plus icon, rotating colors)

### DIFF
--- a/src/components/word/word-form.tsx
+++ b/src/components/word/word-form.tsx
@@ -14,8 +14,6 @@ import type { MeaningView } from '@/lib/dto/meaning';
 import type { WordView } from '@/lib/dto/word';
 import { useActionState, useRef, useState } from 'react';
 
-const MAX_EXAMPLES_PER_MEANING = 2;
-
 type ExampleRow = {
   rowKey: string;
   id?: number;
@@ -27,7 +25,7 @@ type MeaningRow = {
   rowKey: string;
   id?: number;
   definition: string;
-  examples: ExampleRow[];
+  example: ExampleRow;
 };
 
 type WordFormProps = {
@@ -38,19 +36,35 @@ type WordFormProps = {
 
 function buildInitialRows(meanings: MeaningView[]): MeaningRow[] {
   if (meanings.length === 0) {
-    return [{ rowKey: 'new-0', definition: '', examples: [] }];
+    return [
+      {
+        rowKey: 'new-0',
+        definition: '',
+        example: { rowKey: 'new-e-0', sentence: '', translation: '' },
+      },
+    ];
   }
-  return meanings.map((m) => ({
-    rowKey: `existing-m-${m.id}`,
-    id: m.id,
-    definition: m.definition,
-    examples: m.examples.map((e) => ({
-      rowKey: `existing-e-${e.id}`,
-      id: e.id,
-      sentence: e.sentence,
-      translation: e.translation,
-    })),
-  }));
+  return meanings.map((m) => {
+    const firstExample = m.examples[0];
+    return {
+      rowKey: `existing-m-${m.id}`,
+      id: m.id,
+      definition: m.definition,
+      example:
+        firstExample === undefined
+          ? {
+              rowKey: `new-e-for-m-${m.id}`,
+              sentence: '',
+              translation: '',
+            }
+          : {
+              rowKey: `existing-e-${firstExample.id}`,
+              id: firstExample.id,
+              sentence: firstExample.sentence,
+              translation: firstExample.translation,
+            },
+    };
+  });
 }
 
 export function WordForm({
@@ -69,7 +83,6 @@ export function WordForm({
     buildInitialRows(meanings)
   );
   const [removedMeaningIds, setRemovedMeaningIds] = useState<number[]>([]);
-  const [removedExampleRefs, setRemovedExampleRefs] = useState<string[]>([]);
 
   const counterRef = useRef(0);
   const nextKey = (prefix: string) => {
@@ -87,9 +100,14 @@ export function WordForm({
   };
 
   const addMeaning = () => {
+    const k = nextKey('new-m');
     setRows((prev) => [
       ...prev,
-      { rowKey: nextKey('new-m'), definition: '', examples: [] },
+      {
+        rowKey: k,
+        definition: '',
+        example: { rowKey: `${k}-e`, sentence: '', translation: '' },
+      },
     ]);
   };
 
@@ -103,45 +121,18 @@ export function WordForm({
     }
     setRows((prev) => {
       const next = prev.filter((m) => m.rowKey !== rowKey);
-      return next.length === 0
-        ? [{ rowKey: nextKey('new-m'), definition: '', examples: [] }]
-        : next;
+      if (next.length === 0) {
+        const k = nextKey('new-m');
+        return [
+          {
+            rowKey: k,
+            definition: '',
+            example: { rowKey: `${k}-e`, sentence: '', translation: '' },
+          },
+        ];
+      }
+      return next;
     });
-  };
-
-  const addExample = (meaningRowKey: string) => {
-    updateMeaningRow(meaningRowKey, (m) => ({
-      ...m,
-      examples: [
-        ...m.examples,
-        { rowKey: nextKey('new-e'), sentence: '', translation: '' },
-      ],
-    }));
-  };
-
-  const removeExample = (meaningRowKey: string, exampleRowKey: string) => {
-    const meaning = rows.find((m) => m.rowKey === meaningRowKey);
-    const target = meaning?.examples.find((e) => e.rowKey === exampleRowKey);
-    if (
-      target?.id !== undefined &&
-      meaning !== undefined &&
-      meaning.id !== undefined
-    ) {
-      const ref = `${meaning.id}:${target.id}`;
-      setRemovedExampleRefs((refs) =>
-        refs.includes(ref) ? refs : [...refs, ref]
-      );
-    }
-    setRows((prev) =>
-      prev.map((m) =>
-        m.rowKey === meaningRowKey
-          ? {
-              ...m,
-              examples: m.examples.filter((e) => e.rowKey !== exampleRowKey),
-            }
-          : m
-      )
-    );
   };
 
   return (
@@ -157,14 +148,6 @@ export function WordForm({
               type="hidden"
               name="removedMeaningIds"
               value={id}
-            />
-          ))}
-          {removedExampleRefs.map((ref) => (
-            <input
-              key={`rm-e-${ref}`}
-              type="hidden"
-              name="removedExampleRefs"
-              value={ref}
             />
           ))}
         </>
@@ -240,78 +223,44 @@ export function WordForm({
                 </Button>
               </div>
 
-              <div className="space-y-3 pl-2">
-                {m.examples.map((ex, j) => (
-                  <div
-                    key={ex.rowKey}
-                    className="space-y-2 rounded-md border border-dashed p-3"
-                  >
-                    {ex.id !== undefined && (
-                      <input
-                        type="hidden"
-                        name={`meanings[${i}][examples][${j}][id]`}
-                        value={ex.id}
-                      />
-                    )}
-                    <div className="flex items-center justify-between">
-                      <Label htmlFor={`ex-sent-${ex.rowKey}`}>
-                        例文 {j + 1}
-                      </Label>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => removeExample(m.rowKey, ex.rowKey)}
-                      >
-                        削除
-                      </Button>
-                    </div>
-                    <Textarea
-                      id={`ex-sent-${ex.rowKey}`}
-                      name={`meanings[${i}][examples][${j}][sentence]`}
-                      value={ex.sentence}
-                      onChange={(e) =>
-                        updateMeaningRow(m.rowKey, (mm) => ({
-                          ...mm,
-                          examples: mm.examples.map((eee) =>
-                            eee.rowKey === ex.rowKey
-                              ? { ...eee, sentence: e.target.value }
-                              : eee
-                          ),
-                        }))
-                      }
-                      placeholder="例: I ate an apple."
-                      rows={2}
-                    />
-                    <Textarea
-                      id={`ex-trans-${ex.rowKey}`}
-                      name={`meanings[${i}][examples][${j}][translation]`}
-                      value={ex.translation}
-                      onChange={(e) =>
-                        updateMeaningRow(m.rowKey, (mm) => ({
-                          ...mm,
-                          examples: mm.examples.map((eee) =>
-                            eee.rowKey === ex.rowKey
-                              ? { ...eee, translation: e.target.value }
-                              : eee
-                          ),
-                        }))
-                      }
-                      placeholder="例: 私はりんごを食べた。"
-                      rows={2}
-                    />
-                  </div>
-                ))}
-                {m.examples.length < MAX_EXAMPLES_PER_MEANING && (
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={() => addExample(m.rowKey)}
-                  >
-                    例文を追加
-                  </Button>
+              <div className="space-y-2 rounded-md border border-dashed p-3">
+                {m.example.id !== undefined && (
+                  <input
+                    type="hidden"
+                    name={`meanings[${i}][examples][0][id]`}
+                    value={m.example.id}
+                  />
                 )}
+                <Label htmlFor={`ex-sent-${m.example.rowKey}`}>例文</Label>
+                <Textarea
+                  id={`ex-sent-${m.example.rowKey}`}
+                  name={`meanings[${i}][examples][0][sentence]`}
+                  value={m.example.sentence}
+                  onChange={(e) =>
+                    updateMeaningRow(m.rowKey, (mm) => ({
+                      ...mm,
+                      example: { ...mm.example, sentence: e.target.value },
+                    }))
+                  }
+                  placeholder="例: I ate an apple."
+                  rows={2}
+                />
+                <Textarea
+                  id={`ex-trans-${m.example.rowKey}`}
+                  name={`meanings[${i}][examples][0][translation]`}
+                  value={m.example.translation}
+                  onChange={(e) =>
+                    updateMeaningRow(m.rowKey, (mm) => ({
+                      ...mm,
+                      example: {
+                        ...mm.example,
+                        translation: e.target.value,
+                      },
+                    }))
+                  }
+                  placeholder="例: 私はりんごを食べた。"
+                  rows={2}
+                />
               </div>
             </li>
           ))}

--- a/src/components/word/word-form.tsx
+++ b/src/components/word/word-form.tsx
@@ -12,7 +12,16 @@ import {
 } from '@/lib/actions/word-actions';
 import type { MeaningView } from '@/lib/dto/meaning';
 import type { WordView } from '@/lib/dto/word';
+import { Plus } from 'lucide-react';
 import { useActionState, useRef, useState } from 'react';
+
+const MEANING_CARD_CLASSES = [
+  'bg-blue-50 border-blue-200',
+  'bg-pink-50 border-pink-200',
+  'bg-amber-50 border-amber-200',
+  'bg-green-50 border-green-200',
+  'bg-purple-50 border-purple-200',
+];
 
 type ExampleRow = {
   rowKey: string;
@@ -176,6 +185,7 @@ export function WordForm({
             size="sm"
             onClick={addMeaning}
           >
+            <Plus className="mr-2 h-4 w-4" />
             意味を追加
           </Button>
         </div>
@@ -184,7 +194,9 @@ export function WordForm({
           {rows.map((m, i) => (
             <li
               key={m.rowKey}
-              className="space-y-3 rounded-md border p-4"
+              className={`space-y-3 rounded-md border p-4 ${
+                MEANING_CARD_CLASSES[i % MEANING_CARD_CLASSES.length]
+              }`}
             >
               {m.id !== undefined && (
                 <input
@@ -223,7 +235,7 @@ export function WordForm({
                 </Button>
               </div>
 
-              <div className="space-y-2 rounded-md border border-dashed p-3">
+              <div className="space-y-2 rounded-md border border-dashed bg-white/70 p-3">
                 {m.example.id !== undefined && (
                   <input
                     type="hidden"

--- a/src/lib/actions/word-actions.ts
+++ b/src/lib/actions/word-actions.ts
@@ -209,6 +209,22 @@ function parseRemovedExampleRefs(
     .filter((r) => !Number.isNaN(r.meaningId) && !Number.isNaN(r.exampleId));
 }
 
+function collectClearedExamples(
+  parsed: ParsedMeaning[]
+): Array<{ meaningId: number; exampleId: number }> {
+  const result: Array<{ meaningId: number; exampleId: number }> = [];
+  for (const m of parsed) {
+    if (m.id === undefined) continue;
+    for (const e of m.examples) {
+      if (e.id === undefined) continue;
+      if (e.sentence === '' || e.translation === '') {
+        result.push({ meaningId: m.id, exampleId: e.id });
+      }
+    }
+  }
+  return result;
+}
+
 export async function createWordAction(
   _prevState: WordActionState,
   formData: FormData
@@ -266,7 +282,18 @@ export async function updateWordAction(
   const meanings_attributes = buildUpdateMeaningsAttributes(parsed);
 
   const removedMeaningIds = parseRemovedMeaningIds(formData);
-  const removedExampleRefs = parseRemovedExampleRefs(formData);
+  const explicitExampleRefs = parseRemovedExampleRefs(formData);
+  const clearedExampleRefs = collectClearedExamples(parsed);
+
+  const exampleRefKeys = new Set<string>();
+  const mergedExampleRefs: Array<{ meaningId: number; exampleId: number }> =
+    [];
+  for (const ref of [...explicitExampleRefs, ...clearedExampleRefs]) {
+    const key = `${ref.meaningId}:${ref.exampleId}`;
+    if (exampleRefKeys.has(key)) continue;
+    exampleRefKeys.add(key);
+    mergedExampleRefs.push(ref);
+  }
 
   try {
     await updateWord(Number(wordbookId), Number(wordId), {
@@ -276,7 +303,7 @@ export async function updateWordAction(
     });
 
     const meaningIdsToDelete = new Set(removedMeaningIds);
-    for (const { meaningId, exampleId } of removedExampleRefs) {
+    for (const { meaningId, exampleId } of mergedExampleRefs) {
       if (meaningIdsToDelete.has(meaningId)) continue;
       await deleteExample(
         Number(wordbookId),


### PR DESCRIPTION
## Summary

Stacked on top of #101. Addresses post-merge feedback on the multiple-meanings UI:

- **1 example per meaning**: removed the "max 2 examples" feature and the per-example add/delete buttons. Each meaning card now shows exactly one example slot (sentence + translation).
- **Implicit example deletion**: when an existing example's sentence/translation is cleared on update, the server action automatically fires `DELETE /examples/:id`. Replaces the previous explicit delete button for examples.
- **Plus icon** on "意味を追加" using `lucide-react`'s `Plus`, matching the pattern used in dashboard / wordbook detail.
- **Rotating card colors** for meanings — 5 pastel backgrounds (blue / pink / amber / green / purple) cycling so multiple meanings are visually distinguishable at a glance.

Pre-existing data with 2+ examples per meaning is treated as out-of-scope (confirmed with the user — such data effectively doesn't exist).

## Test plan

- [x] Create a word with 6 meanings and confirm the 6th cycles back to blue
- [x] Confirm the `+` icon appears on the "意味を追加" button
- [x] Confirm each meaning card has one example slot only, no add/remove example buttons
- [x] Save a word with an example, then re-open the edit form, clear both example fields, save → detail page no longer shows the example and reopening edit shows the slot empty (= API-level delete fired)
- [x] `pnpm lint` / `pnpm build`