### PR TITLE
Drag-and-drop reorder for word meanings

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "test:e2e:headed": "playwright test --headed"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-slot": "^1.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.0)
       '@radix-ui/react-avatar':
         specifier: ^1.1.11
         version: 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -201,6 +210,28 @@ packages:
   '@babel/types@7.28.5':
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@emnapi/core@1.7.1':
     resolution: {integrity: sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg==}
@@ -3167,6 +3198,31 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.0)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.0)
+      react: 19.2.0
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+      tslib: 2.8.1
 
   '@emnapi/core@1.7.1':
     dependencies:

--- a/src/app/(authenticated)/wordbooks/[wordbookId]/words/[wordId]/word-detail-content.tsx
+++ b/src/app/(authenticated)/wordbooks/[wordbookId]/words/[wordId]/word-detail-content.tsx
@@ -55,7 +55,11 @@ export async function WordDetailContent({
 
       <Card>
         <CardContent className="pt-6">
-          <WordDetail word={word} meanings={sortedMeanings} />
+          <WordDetail
+            wordbookId={Number(wordbookId)}
+            word={word}
+            meanings={sortedMeanings}
+          />
         </CardContent>
       </Card>
     </>

--- a/src/components/word/meaning-card-classes.ts
+++ b/src/components/word/meaning-card-classes.ts
@@ -1,0 +1,11 @@
+export const MEANING_CARD_CLASSES = [
+  'bg-blue-50 border-blue-200',
+  'bg-pink-50 border-pink-200',
+  'bg-amber-50 border-amber-200',
+  'bg-green-50 border-green-200',
+  'bg-purple-50 border-purple-200',
+];
+
+export function meaningCardClass(index: number): string {
+  return MEANING_CARD_CLASSES[index % MEANING_CARD_CLASSES.length];
+}

--- a/src/components/word/word-detail-meanings.tsx
+++ b/src/components/word/word-detail-meanings.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import { reorderMeaningsAction } from '@/lib/actions/word-actions';
+import type { MeaningView } from '@/lib/dto/meaning';
+import {
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { GripVertical } from 'lucide-react';
+import { useState, useTransition } from 'react';
+import { meaningCardClass } from './meaning-card-classes';
+
+type WordDetailMeaningsProps = {
+  wordbookId: number;
+  wordId: number;
+  meanings: MeaningView[];
+};
+
+export function WordDetailMeanings({
+  wordbookId,
+  wordId,
+  meanings,
+}: WordDetailMeaningsProps) {
+  const [items, setItems] = useState<MeaningView[]>(meanings);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isSaving, startTransition] = useTransition();
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 4 },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (over === null || active.id === over.id) return;
+
+    const oldIndex = items.findIndex((m) => m.id === active.id);
+    const newIndex = items.findIndex((m) => m.id === over.id);
+    if (oldIndex === -1 || newIndex === -1) return;
+
+    const previous = items;
+    const reordered = arrayMove(items, oldIndex, newIndex);
+    setItems(reordered);
+    setErrorMessage(null);
+
+    startTransition(async () => {
+      const result = await reorderMeaningsAction(
+        wordbookId,
+        wordId,
+        reordered.map((m) => m.id)
+      );
+      if (result.errors !== undefined && result.errors.length > 0) {
+        setItems(previous);
+        setErrorMessage(result.errors[0] ?? '並び替えに失敗しました');
+      }
+    });
+  };
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-2">
+        <h3 className="text-sm font-medium text-muted-foreground">意味</h3>
+        {isSaving && (
+          <span className="text-xs text-muted-foreground">保存中...</span>
+        )}
+      </div>
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
+      >
+        <SortableContext
+          items={items.map((m) => m.id)}
+          strategy={verticalListSortingStrategy}
+        >
+          <ul className="space-y-4">
+            {items.map((meaning, index) => (
+              <SortableMeaningItem
+                key={meaning.id}
+                meaning={meaning}
+                index={index}
+              />
+            ))}
+          </ul>
+        </SortableContext>
+      </DndContext>
+      {errorMessage !== null && (
+        <p className="mt-2 text-sm text-destructive">{errorMessage}</p>
+      )}
+    </div>
+  );
+}
+
+type SortableMeaningItemProps = {
+  meaning: MeaningView;
+  index: number;
+};
+
+function SortableMeaningItem({ meaning, index }: SortableMeaningItemProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: meaning.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.6 : 1,
+  };
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={style}
+      className={`flex gap-3 rounded-md border p-4 ${meaningCardClass(index)}`}
+    >
+      <button
+        type="button"
+        {...attributes}
+        {...listeners}
+        aria-label={`意味 ${index + 1} を並び替え`}
+        className="flex h-8 w-8 shrink-0 cursor-grab touch-none items-center justify-center rounded text-muted-foreground hover:bg-black/5 active:cursor-grabbing"
+      >
+        <GripVertical className="h-5 w-5" />
+      </button>
+      <div className="flex-1 space-y-2">
+        <p className="text-lg">{meaning.definition}</p>
+        {meaning.examples.length > 0 && (
+          <ul className="space-y-2 pl-4 border-l-2 border-muted">
+            {meaning.examples.map((example) => (
+              <li key={example.id} className="space-y-1">
+                <p className="text-base">{example.sentence}</p>
+                <p className="text-sm text-muted-foreground">
+                  {example.translation}
+                </p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </li>
+  );
+}

--- a/src/components/word/word-detail.tsx
+++ b/src/components/word/word-detail.tsx
@@ -2,14 +2,16 @@ import { Separator } from '@/components/ui/separator';
 import { AudioPlayButton } from '@/components/audio/audio-play-button';
 import type { MeaningView } from '@/lib/dto/meaning';
 import type { WordView } from '@/lib/dto/word';
+import { WordDetailMeanings } from './word-detail-meanings';
 import { WordStatusBadge } from './word-status-badge';
 
 type WordDetailProps = {
+  wordbookId: number;
   word: WordView;
   meanings: MeaningView[];
 };
 
-export function WordDetail({ word, meanings }: WordDetailProps) {
+export function WordDetail({ wordbookId, word, meanings }: WordDetailProps) {
   return (
     <div className="space-y-6">
       <div className="flex items-center gap-3">
@@ -19,30 +21,11 @@ export function WordDetail({ word, meanings }: WordDetailProps) {
       </div>
 
       {meanings.length > 0 && (
-        <div>
-          <h3 className="text-sm font-medium text-muted-foreground mb-2">
-            意味
-          </h3>
-          <ul className="space-y-4">
-            {meanings.map((meaning) => (
-              <li key={meaning.id} className="space-y-2">
-                <p className="text-lg">{meaning.definition}</p>
-                {meaning.examples.length > 0 && (
-                  <ul className="space-y-2 pl-4 border-l-2 border-muted">
-                    {meaning.examples.map((example) => (
-                      <li key={example.id} className="space-y-1">
-                        <p className="text-base">{example.sentence}</p>
-                        <p className="text-sm text-muted-foreground">
-                          {example.translation}
-                        </p>
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </li>
-            ))}
-          </ul>
-        </div>
+        <WordDetailMeanings
+          wordbookId={wordbookId}
+          wordId={word.id}
+          meanings={meanings}
+        />
       )}
 
       {word.next_review_at !== null && (

--- a/src/components/word/word-form.tsx
+++ b/src/components/word/word-form.tsx
@@ -13,6 +13,7 @@ import {
 import type { MeaningView } from '@/lib/dto/meaning';
 import type { WordView } from '@/lib/dto/word';
 import { useActionState, useRef, useState } from 'react';
+import { meaningCardClass } from './meaning-card-classes';
 
 const MAX_EXAMPLES_PER_MEANING = 2;
 
@@ -201,7 +202,7 @@ export function WordForm({
           {rows.map((m, i) => (
             <li
               key={m.rowKey}
-              className="space-y-3 rounded-md border p-4"
+              className={`space-y-3 rounded-md border p-4 ${meaningCardClass(i)}`}
             >
               {m.id !== undefined && (
                 <input
@@ -244,7 +245,7 @@ export function WordForm({
                 {m.examples.map((ex, j) => (
                   <div
                     key={ex.rowKey}
-                    className="space-y-2 rounded-md border border-dashed p-3"
+                    className="space-y-2 rounded-md border border-dashed bg-white/70 p-3"
                   >
                     {ex.id !== undefined && (
                       <input

--- a/src/lib/actions/word-actions.ts
+++ b/src/lib/actions/word-actions.ts
@@ -302,6 +302,29 @@ export async function updateWordAction(
   }
 }
 
+export async function reorderMeaningsAction(
+  wordbookId: number,
+  wordId: number,
+  orderedMeaningIds: number[]
+): Promise<WordActionState> {
+  const meanings_attributes: UpdateMeaningNestedInput[] = orderedMeaningIds.map(
+    (id, i) => ({ id, display_order: i + 1 })
+  );
+
+  try {
+    await updateWord(wordbookId, wordId, { meanings_attributes });
+    revalidatePath(`/wordbooks/${wordbookId}`);
+    revalidatePath(`/wordbooks/${wordbookId}/words/${wordId}`);
+    return {};
+  } catch (error) {
+    if (error instanceof ApiError) {
+      const body = error.body as { errors?: string[] } | null;
+      return { errors: body?.errors ?? ['並び替えに失敗しました'] };
+    }
+    throw error;
+  }
+}
+
 export async function updateWordStatusAction(
   wordId: number,
   wordbookId: number,


### PR DESCRIPTION
## Summary
- Make the meaning list on the word detail page sortable via drag-and-drop using `@dnd-kit`, with a `GripVertical` handle on each card.
- Rotate meaning card colors by position (blue → pink → amber → green → purple) so the color follows the slot, not the meaning. The same palette is now shared between `WordForm` and the new sortable list via `meaning-card-classes.ts`.
- Persist the new order on drop with a new `reorderMeaningsAction` that updates `display_order` for every meaning. Optimistic UI rolls back and surfaces an error message if the action fails.

## Test plan
- [x] Visit a word detail page with 2+ meanings; confirm cards display with the rotating palette and a left-side grip handle.
- [x] Drag a card to a new position; confirm the order updates locally and a brief "保存中..." indicator appears.
- [x] Reload the page; confirm the new order is persisted.
- [x] Open the corresponding edit form and confirm meaning cards use the same palette.
- [x] Run `pnpm lint` and `pnpm exec tsc --noEmit`.