### PR TITLE
Tighten word display: cap meanings/examples and fix reorder revalidate

### DIFF
--- a/src/components/test/flashcard.tsx
+++ b/src/components/test/flashcard.tsx
@@ -1,10 +1,8 @@
 'use client';
 
-import { ChevronDown, ChevronUp } from 'lucide-react';
 import { useState } from 'react';
 
 import { AudioPlayButton } from '@/components/audio/audio-play-button';
-import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import type { MeaningView } from '@/lib/dto/meaning';
 import type { WordView } from '@/lib/dto/word';
@@ -16,10 +14,8 @@ type FlashcardProps = {
 
 export function Flashcard({ word, meanings }: FlashcardProps) {
   const [isFlipped, setIsFlipped] = useState(false);
-  const [meaningsExpanded, setMeaningsExpanded] = useState(false);
 
-  const visibleMeanings = meaningsExpanded ? meanings : meanings.slice(0, 3);
-  const hiddenMeaningsCount = meanings.length - 3;
+  const primaryMeaning = meanings[0];
 
   return (
     <div
@@ -43,62 +39,19 @@ export function Flashcard({ word, meanings }: FlashcardProps) {
               <p className="text-xl font-semibold text-muted-foreground">
                 {word.spelling}
               </p>
-              {meanings.length > 0 && (
+              {primaryMeaning !== undefined && (
                 <div className="space-y-3">
-                  {visibleMeanings.map((meaning, index) => (
-                    <div key={meaning.id} className="space-y-1">
-                      <p
-                        className={
-                          index === 0
-                            ? 'text-2xl font-bold'
-                            : 'text-base text-muted-foreground'
-                        }
-                      >
-                        {meaning.definition}
+                  <p className="text-2xl font-bold">
+                    {primaryMeaning.definition}
+                  </p>
+                  {primaryMeaning.examples.map((example) => (
+                    <div key={example.id} className="space-y-1 text-sm">
+                      <p className="text-foreground">{example.sentence}</p>
+                      <p className="text-muted-foreground">
+                        {example.translation}
                       </p>
-                      {meaning.examples.length > 0 && (
-                        <div className="space-y-1">
-                          {meaning.examples.map((example) => (
-                            <div
-                              key={example.id}
-                              className={
-                                index === 0
-                                  ? 'text-sm'
-                                  : 'text-xs text-muted-foreground'
-                              }
-                            >
-                              <p className="text-foreground">
-                                {example.sentence}
-                              </p>
-                              <p className="text-muted-foreground">
-                                {example.translation}
-                              </p>
-                            </div>
-                          ))}
-                        </div>
-                      )}
                     </div>
                   ))}
-                  {hiddenMeaningsCount > 0 && (
-                    <div onClick={(e) => e.stopPropagation()}>
-                      <Button
-                        variant="ghost"
-                        size="xs"
-                        onClick={() => setMeaningsExpanded(!meaningsExpanded)}
-                      >
-                        {meaningsExpanded ? (
-                          <>
-                            <ChevronUp />
-                            閉じる
-                          </>
-                        ) : (
-                          <>
-                            <ChevronDown />+{hiddenMeaningsCount} more
-                          </>
-                        )}
-                      </Button>
-                    </div>
-                  )}
                 </div>
               )}
             </div>

--- a/src/components/word/word-detail-meanings.tsx
+++ b/src/components/word/word-detail-meanings.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@/components/ui/button';
 import { reorderMeaningsAction } from '@/lib/actions/word-actions';
 import type { MeaningView } from '@/lib/dto/meaning';
 import {
@@ -19,9 +20,11 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { GripVertical } from 'lucide-react';
+import { ChevronDown, ChevronUp, GripVertical } from 'lucide-react';
 import { useState, useTransition } from 'react';
 import { meaningCardClass } from './meaning-card-classes';
+
+const COLLAPSED_COUNT = 2;
 
 type WordDetailMeaningsProps = {
   wordbookId: number;
@@ -36,7 +39,14 @@ export function WordDetailMeanings({
 }: WordDetailMeaningsProps) {
   const [items, setItems] = useState<MeaningView[]>(meanings);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isExpanded, setIsExpanded] = useState(false);
   const [isSaving, startTransition] = useTransition();
+
+  const visibleItems =
+    isExpanded || items.length <= COLLAPSED_COUNT
+      ? items
+      : items.slice(0, COLLAPSED_COUNT);
+  const hiddenCount = items.length - visibleItems.length;
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -87,11 +97,11 @@ export function WordDetailMeanings({
         onDragEnd={handleDragEnd}
       >
         <SortableContext
-          items={items.map((m) => m.id)}
+          items={visibleItems.map((m) => m.id)}
           strategy={verticalListSortingStrategy}
         >
           <ul className="space-y-4">
-            {items.map((meaning, index) => (
+            {visibleItems.map((meaning, index) => (
               <SortableMeaningItem
                 key={meaning.id}
                 meaning={meaning}
@@ -101,6 +111,28 @@ export function WordDetailMeanings({
           </ul>
         </SortableContext>
       </DndContext>
+      {items.length > COLLAPSED_COUNT && (
+        <div className="mt-3 flex justify-center">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => setIsExpanded((v) => !v)}
+          >
+            {isExpanded ? (
+              <>
+                <ChevronUp />
+                閉じる
+              </>
+            ) : (
+              <>
+                <ChevronDown />
+                もっと表示 (+{hiddenCount})
+              </>
+            )}
+          </Button>
+        </div>
+      )}
       {errorMessage !== null && (
         <p className="mt-2 text-sm text-destructive">{errorMessage}</p>
       )}

--- a/src/components/word/word-detail-meanings.tsx
+++ b/src/components/word/word-detail-meanings.tsx
@@ -21,6 +21,7 @@ import {
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { ChevronDown, ChevronUp, GripVertical } from 'lucide-react';
+import { useRouter } from 'next/navigation';
 import { useState, useTransition } from 'react';
 import { meaningCardClass } from './meaning-card-classes';
 
@@ -37,6 +38,7 @@ export function WordDetailMeanings({
   wordId,
   meanings,
 }: WordDetailMeaningsProps) {
+  const router = useRouter();
   const [items, setItems] = useState<MeaningView[]>(meanings);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isExpanded, setIsExpanded] = useState(false);
@@ -79,7 +81,9 @@ export function WordDetailMeanings({
       if (result.errors !== undefined && result.errors.length > 0) {
         setItems(previous);
         setErrorMessage(result.errors[0] ?? '並び替えに失敗しました');
+        return;
       }
+      router.refresh();
     });
   };
 

--- a/src/components/word/word-form.tsx
+++ b/src/components/word/word-form.tsx
@@ -15,8 +15,6 @@ import type { WordView } from '@/lib/dto/word';
 import { useActionState, useRef, useState } from 'react';
 import { meaningCardClass } from './meaning-card-classes';
 
-const MAX_EXAMPLES_PER_MEANING = 2;
-
 type ExampleRow = {
   rowKey: string;
   id?: number;
@@ -28,7 +26,7 @@ type MeaningRow = {
   rowKey: string;
   id?: number;
   definition: string;
-  examples: ExampleRow[];
+  example: ExampleRow;
 };
 
 type WordFormProps = {
@@ -37,21 +35,50 @@ type WordFormProps = {
   meanings?: MeaningView[];
 };
 
-function buildInitialRows(meanings: MeaningView[]): MeaningRow[] {
+function emptyExample(rowKey: string): ExampleRow {
+  return { rowKey, sentence: '', translation: '' };
+}
+
+function buildInitialState(meanings: MeaningView[]): {
+  rows: MeaningRow[];
+  removedExampleRefs: string[];
+} {
   if (meanings.length === 0) {
-    return [{ rowKey: 'new-0', definition: '', examples: [] }];
+    return {
+      rows: [
+        {
+          rowKey: 'new-m-0',
+          definition: '',
+          example: emptyExample('new-e-0'),
+        },
+      ],
+      removedExampleRefs: [],
+    };
   }
-  return meanings.map((m) => ({
-    rowKey: `existing-m-${m.id}`,
-    id: m.id,
-    definition: m.definition,
-    examples: m.examples.map((e) => ({
-      rowKey: `existing-e-${e.id}`,
-      id: e.id,
-      sentence: e.sentence,
-      translation: e.translation,
-    })),
-  }));
+
+  const removedExampleRefs: string[] = [];
+  const rows = meanings.map((m) => {
+    const [first, ...rest] = m.examples;
+    for (const e of rest) {
+      removedExampleRefs.push(`${m.id}:${e.id}`);
+    }
+    const example: ExampleRow =
+      first === undefined
+        ? emptyExample(`existing-e-empty-${m.id}`)
+        : {
+            rowKey: `existing-e-${first.id}`,
+            id: first.id,
+            sentence: first.sentence,
+            translation: first.translation,
+          };
+    return {
+      rowKey: `existing-m-${m.id}`,
+      id: m.id,
+      definition: m.definition,
+      example,
+    };
+  });
+  return { rows, removedExampleRefs };
 }
 
 export function WordForm({
@@ -66,11 +93,10 @@ export function WordForm({
     FormData
   >(action, {});
 
-  const [rows, setRows] = useState<MeaningRow[]>(() =>
-    buildInitialRows(meanings)
-  );
+  const [initial] = useState(() => buildInitialState(meanings));
+  const [rows, setRows] = useState<MeaningRow[]>(initial.rows);
   const [removedMeaningIds, setRemovedMeaningIds] = useState<number[]>([]);
-  const [removedExampleRefs, setRemovedExampleRefs] = useState<string[]>([]);
+  const [removedExampleRefs] = useState<string[]>(initial.removedExampleRefs);
 
   const counterRef = useRef(0);
   const nextKey = (prefix: string) => {
@@ -90,7 +116,11 @@ export function WordForm({
   const addMeaning = () => {
     setRows((prev) => [
       ...prev,
-      { rowKey: nextKey('new-m'), definition: '', examples: [] },
+      {
+        rowKey: nextKey('new-m'),
+        definition: '',
+        example: emptyExample(nextKey('new-e')),
+      },
     ]);
   };
 
@@ -105,44 +135,15 @@ export function WordForm({
     setRows((prev) => {
       const next = prev.filter((m) => m.rowKey !== rowKey);
       return next.length === 0
-        ? [{ rowKey: nextKey('new-m'), definition: '', examples: [] }]
+        ? [
+            {
+              rowKey: nextKey('new-m'),
+              definition: '',
+              example: emptyExample(nextKey('new-e')),
+            },
+          ]
         : next;
     });
-  };
-
-  const addExample = (meaningRowKey: string) => {
-    updateMeaningRow(meaningRowKey, (m) => ({
-      ...m,
-      examples: [
-        ...m.examples,
-        { rowKey: nextKey('new-e'), sentence: '', translation: '' },
-      ],
-    }));
-  };
-
-  const removeExample = (meaningRowKey: string, exampleRowKey: string) => {
-    const meaning = rows.find((m) => m.rowKey === meaningRowKey);
-    const target = meaning?.examples.find((e) => e.rowKey === exampleRowKey);
-    if (
-      target?.id !== undefined &&
-      meaning !== undefined &&
-      meaning.id !== undefined
-    ) {
-      const ref = `${meaning.id}:${target.id}`;
-      setRemovedExampleRefs((refs) =>
-        refs.includes(ref) ? refs : [...refs, ref]
-      );
-    }
-    setRows((prev) =>
-      prev.map((m) =>
-        m.rowKey === meaningRowKey
-          ? {
-              ...m,
-              examples: m.examples.filter((e) => e.rowKey !== exampleRowKey),
-            }
-          : m
-      )
-    );
   };
 
   return (
@@ -241,78 +242,44 @@ export function WordForm({
                 </Button>
               </div>
 
-              <div className="space-y-3 pl-2">
-                {m.examples.map((ex, j) => (
-                  <div
-                    key={ex.rowKey}
-                    className="space-y-2 rounded-md border border-dashed bg-white/70 p-3"
-                  >
-                    {ex.id !== undefined && (
-                      <input
-                        type="hidden"
-                        name={`meanings[${i}][examples][${j}][id]`}
-                        value={ex.id}
-                      />
-                    )}
-                    <div className="flex items-center justify-between">
-                      <Label htmlFor={`ex-sent-${ex.rowKey}`}>
-                        例文 {j + 1}
-                      </Label>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => removeExample(m.rowKey, ex.rowKey)}
-                      >
-                        削除
-                      </Button>
-                    </div>
-                    <Textarea
-                      id={`ex-sent-${ex.rowKey}`}
-                      name={`meanings[${i}][examples][${j}][sentence]`}
-                      value={ex.sentence}
-                      onChange={(e) =>
-                        updateMeaningRow(m.rowKey, (mm) => ({
-                          ...mm,
-                          examples: mm.examples.map((eee) =>
-                            eee.rowKey === ex.rowKey
-                              ? { ...eee, sentence: e.target.value }
-                              : eee
-                          ),
-                        }))
-                      }
-                      placeholder="例: I ate an apple."
-                      rows={2}
-                    />
-                    <Textarea
-                      id={`ex-trans-${ex.rowKey}`}
-                      name={`meanings[${i}][examples][${j}][translation]`}
-                      value={ex.translation}
-                      onChange={(e) =>
-                        updateMeaningRow(m.rowKey, (mm) => ({
-                          ...mm,
-                          examples: mm.examples.map((eee) =>
-                            eee.rowKey === ex.rowKey
-                              ? { ...eee, translation: e.target.value }
-                              : eee
-                          ),
-                        }))
-                      }
-                      placeholder="例: 私はりんごを食べた。"
-                      rows={2}
-                    />
-                  </div>
-                ))}
-                {m.examples.length < MAX_EXAMPLES_PER_MEANING && (
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={() => addExample(m.rowKey)}
-                  >
-                    例文を追加
-                  </Button>
+              <div className="space-y-2 rounded-md border border-dashed bg-white/70 p-3">
+                {m.example.id !== undefined && (
+                  <input
+                    type="hidden"
+                    name={`meanings[${i}][examples][0][id]`}
+                    value={m.example.id}
+                  />
                 )}
+                <Label htmlFor={`ex-sent-${m.rowKey}`}>例文</Label>
+                <Textarea
+                  id={`ex-sent-${m.rowKey}`}
+                  name={`meanings[${i}][examples][0][sentence]`}
+                  value={m.example.sentence}
+                  onChange={(e) =>
+                    updateMeaningRow(m.rowKey, (mm) => ({
+                      ...mm,
+                      example: { ...mm.example, sentence: e.target.value },
+                    }))
+                  }
+                  placeholder="例: I ate an apple."
+                  rows={2}
+                />
+                <Textarea
+                  id={`ex-trans-${m.rowKey}`}
+                  name={`meanings[${i}][examples][0][translation]`}
+                  value={m.example.translation}
+                  onChange={(e) =>
+                    updateMeaningRow(m.rowKey, (mm) => ({
+                      ...mm,
+                      example: {
+                        ...mm.example,
+                        translation: e.target.value,
+                      },
+                    }))
+                  }
+                  placeholder="例: 私はりんごを食べた。"
+                  rows={2}
+                />
               </div>
             </li>
           ))}

--- a/src/lib/actions/word-actions.ts
+++ b/src/lib/actions/word-actions.ts
@@ -292,6 +292,7 @@ export async function updateWordAction(
     revalidatePath(`/wordbooks/${wordbookId}`);
     revalidatePath(`/wordbooks/${wordbookId}/test`);
     revalidatePath(`/wordbooks/${wordbookId}/words/${wordId}`);
+    revalidatePath(`/wordbooks/${wordbookId}/words/${wordId}/edit`);
     redirect(`/wordbooks/${wordbookId}/words/${wordId}`);
   } catch (error) {
     if (error instanceof ApiError) {
@@ -315,6 +316,7 @@ export async function reorderMeaningsAction(
     await updateWord(wordbookId, wordId, { meanings_attributes });
     revalidatePath(`/wordbooks/${wordbookId}`);
     revalidatePath(`/wordbooks/${wordbookId}/words/${wordId}`);
+    revalidatePath(`/wordbooks/${wordbookId}/words/${wordId}/edit`);
     return {};
   } catch (error) {
     if (error instanceof ApiError) {

--- a/src/lib/dal/client.ts
+++ b/src/lib/dal/client.ts
@@ -44,6 +44,7 @@ export async function apiRequest<T>(options: RequestOptions): Promise<T> {
     method: options.method,
     headers,
     body: options.body !== undefined ? JSON.stringify(options.body) : undefined,
+    cache: 'no-store',
   });
 
   if (!response.ok) {


### PR DESCRIPTION
## Summary
- Show only the first two meanings on the word detail page; reveal the rest with a もっと表示 toggle. Drag-and-drop stays scoped to the visible items so the collapsed view still allows swapping the top two.
- Limit each meaning to a single example in the word form. The 例文を追加 / 削除 controls are gone, and any extra examples on existing words are queued for deletion when the form opens.
- Simplify the flashcard back side to just the first meaning and its example(s); the multi-meaning expand UI is removed.
- Fix the reorder/update flow so the edit page is revalidated after `reorderMeaningsAction` and `updateWordAction`. Previously, reordering on the detail page left the edit page cache showing the old order.

## Test plan
- [x] `pnpm lint`
- [x] Create a word with 3+ meanings, each with an example; confirm the form has no 例文を追加 / 削除 buttons and a single example slot per meaning
- [x] On the detail page, confirm only two meanings are visible by default and もっと表示 (+N) reveals the rest
- [x] In the collapsed state, drag the first two meanings to swap them; expand and reorder across all
- [x] After reordering on the detail page, open the edit page and confirm the order matches
- [x] Open the flashcard test: the back side shows only the first meaning + its examples