### PR TITLE
feat(auth): show default avatar for guest users

### DIFF
--- a/public/guest-avatar.svg
+++ b/public/guest-avatar.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" width="40" height="40" role="img" aria-label="Guest user avatar">
+  <circle cx="20" cy="20" r="20" fill="#e5e7eb" />
+  <circle cx="20" cy="16" r="6" fill="#9ca3af" />
+  <path d="M8 34c0-6.627 5.373-12 12-12s12 5.373 12 12v6H8v-6z" fill="#9ca3af" />
+</svg>

--- a/src/lib/auth/app-providers.ts
+++ b/src/lib/auth/app-providers.ts
@@ -33,6 +33,7 @@ const guestProvider = {
       const guest = await getGuestAuthView();
       return {
         name: guest.name,
+        image: '/guest-avatar.svg',
         accessToken: guest.token,
       };
     },


### PR DESCRIPTION
## Summary

- Add a neutral person-silhouette SVG at `public/guest-avatar.svg` for use as the guest user's default avatar.
- Return `image: '/guest-avatar.svg'` from the guest Credentials provider's `authorize()` in `src/lib/auth/app-providers.ts`. NextAuth propagates it to `session.user.image`, so the existing `<AvatarImage>` in `user-menu-presenter.tsx` picks it up without any header-side changes.

Previously guest sessions had no `image`, and the `/placeholder.svg` fallback referenced by the header does not exist in `public/`, so the avatar rendered as a blank circle.

Closes #12

## Test plan

- [x] `pnpm lint` passes
- [x] Logged in as Guest via `/auth`; confirmed the header avatar renders the person silhouette
- [x] `curl http://localhost:3000/guest-avatar.svg` returns `200`
- [x] Confirmed `<img>` `src` is `/guest-avatar.svg` via Playwright
- [x] OAuth (Google) login still shows the provider-supplied avatar (regression check — requires OAuth creds; not run locally)
