### PR TITLE
test: add core flow e2e coverage

### DIFF
--- a/e2e/core-flows.spec.ts
+++ b/e2e/core-flows.spec.ts
@@ -1,0 +1,203 @@
+import { expect, test, type Page } from '@playwright/test';
+
+import { signInAsGuest } from './fixtures/auth';
+
+function uniqueName(prefix: string): string {
+  return `${prefix} ${Date.now()}`;
+}
+
+async function createWordbook(page: Page, title: string): Promise<string> {
+  await page.getByRole('link', { name: '新しい単語帳' }).click();
+  await expect(page.getByText('新しい単語帳を作成')).toBeVisible();
+  await page.getByLabel('タイトル').fill(title);
+  await page.getByRole('button', { name: '作成する' }).click();
+  await expect(page.getByRole('heading', { name: title })).toBeVisible();
+
+  const match = /\/wordbooks\/(?<id>\d+)$/.exec(page.url());
+  expect(match?.groups?.id).toBeDefined();
+  return match?.groups?.id ?? '';
+}
+
+async function createWord(
+  page: Page,
+  params: {
+    spelling: string;
+    meaning: string;
+    sentence: string;
+    translation: string;
+  },
+): Promise<string> {
+  await page.getByRole('link', { name: '単語を追加' }).click();
+  await page.getByLabel('スペル').fill(params.spelling);
+  await page.getByLabel('意味 1').fill(params.meaning);
+  await page.getByLabel('例文').fill(params.sentence);
+  await page
+    .getByPlaceholder('例: 私はりんごを食べた。')
+    .fill(params.translation);
+  await page.getByRole('button', { name: '登録する' }).click();
+  await expect(page.getByRole('link', { name: params.spelling })).toBeVisible();
+  await page.getByRole('link', { name: params.spelling }).click();
+  await expect(
+    page.getByRole('heading', { name: params.spelling }),
+  ).toBeVisible();
+
+  const match = /\/words\/(?<id>\d+)$/.exec(page.url());
+  expect(match?.groups?.id).toBeDefined();
+  return match?.groups?.id ?? '';
+}
+
+test.describe('Core flows', () => {
+  test('redirects unauthenticated users to auth', async ({ page }) => {
+    await page.goto('/dashboard');
+    await page.waitForURL('/auth');
+    await expect(
+      page.getByRole('button', { name: 'ゲストとして始める' }),
+    ).toBeVisible();
+  });
+
+  test('signs in as a guest and shows the dashboard user menu', async ({
+    page,
+  }) => {
+    await signInAsGuest(page);
+    await page.getByRole('button', { name: 'ゲスト' }).click();
+    await expect(page.getByRole('menu', { name: 'ゲスト' })).toBeVisible();
+    await expect(
+      page.getByText('7日間の有効期限があります', { exact: true }),
+    ).toBeVisible();
+  });
+
+  test('covers wordbook, word, filters, test, delete, and sign out', async ({
+    page,
+  }) => {
+    await signInAsGuest(page);
+
+    const originalTitle = uniqueName('E2E 単語帳');
+    const updatedTitle = `${originalTitle} Updated`;
+    const wordbookId = await createWordbook(page, originalTitle);
+
+    await expect(page.getByRole('link', { name: '編集' })).toBeVisible();
+    await expect(page.getByRole('button', { name: '削除' })).toBeVisible();
+    await expect(page.getByText('まだ単語がありません')).toBeVisible();
+
+    await page.goto('/dashboard');
+    await expect(page.getByRole('link', { name: originalTitle })).toBeVisible();
+
+    await page.goto(`/wordbooks/${wordbookId}/edit`);
+    await page.getByLabel('タイトル').fill(updatedTitle);
+    await page.getByRole('button', { name: '更新する' }).click();
+    await expect(page.getByRole('heading', { name: updatedTitle })).toBeVisible();
+
+    const firstWord = {
+      spelling: uniqueName('aurora'),
+      meaning: '夜明け',
+      sentence: 'The aurora brightened the sky.',
+      translation: 'オーロラが空を明るくした。',
+    };
+    const firstWordId = await createWord(page, firstWord);
+
+    await expect(page.getByText('未学習', { exact: true }).first()).toBeVisible();
+    await expect(page.getByText(firstWord.meaning).first()).toBeVisible();
+    await expect(
+      page.getByRole('paragraph').filter({ hasText: firstWord.sentence }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('paragraph').filter({ hasText: firstWord.translation }),
+    ).toBeVisible();
+
+    const updatedWord = {
+      spelling: `${firstWord.spelling}-edited`,
+      meaning: '極光',
+    };
+    await page.goto(`/wordbooks/${wordbookId}/words/${firstWordId}/edit`);
+    await page.getByLabel('スペル').fill(updatedWord.spelling);
+    await page.getByLabel('意味 1').fill(updatedWord.meaning);
+    await page.getByRole('button', { name: '更新する' }).click();
+    await expect(
+      page.getByRole('heading', { name: updatedWord.spelling }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('paragraph').filter({ hasText: updatedWord.meaning }),
+    ).toBeVisible();
+
+    await page.goto(`/wordbooks/${wordbookId}`);
+    await createWord(page, {
+      spelling: uniqueName('nebula'),
+      meaning: '星雲',
+      sentence: 'A nebula can form new stars.',
+      translation: '星雲は新しい星を形成することがある。',
+    });
+
+    await page.goto(`/wordbooks/${wordbookId}/test`);
+    await expect(page.getByText('1 / 2')).toBeVisible();
+    await expect(page.getByText(updatedWord.spelling)).toBeVisible();
+    await page.getByRole('button', { name: '難しい' }).click();
+    await expect(page.getByText('2 / 2')).toBeVisible();
+    await page.getByRole('button', { name: '簡単' }).click();
+    await expect(page.getByText('テスト完了！')).toBeVisible();
+
+    await page.goto(`/wordbooks/${wordbookId}/words/${firstWordId}`);
+    await expect(page.getByText('難しい')).toBeVisible();
+    await expect(page.getByText('次の復習')).toBeVisible();
+
+    await page.goto('/settings');
+    await expect(page.getByRole('heading', { name: '設定' })).toBeVisible();
+    await page.locator('input[name="hard_days"]').fill('2');
+    await page.locator('input[name="hard_hours"]').fill('3');
+    await page.locator('input[name="hard_minutes"]').fill('4');
+    await page.locator('input[name="uncertain_days"]').fill('5');
+    await page.locator('input[name="easy_days"]').fill('8');
+    await page.getByRole('button', { name: '設定を保存' }).click();
+    await expect(page.getByText('設定を保存しました')).toBeVisible();
+    await page.reload();
+    await expect(page.locator('input[name="hard_days"]')).toHaveValue('2');
+    await expect(page.locator('input[name="hard_hours"]')).toHaveValue('3');
+    await expect(page.locator('input[name="hard_minutes"]')).toHaveValue('4');
+    await expect(page.locator('input[name="uncertain_days"]')).toHaveValue('5');
+    await expect(page.locator('input[name="easy_days"]')).toHaveValue('8');
+
+    await page.goto(`/wordbooks/${wordbookId}?status=hard`);
+    await expect(page.getByRole('tab', { name: '難しい' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    await expect(page.getByRole('link', { name: /aurora/ })).toBeVisible();
+    await expect(page.getByRole('link', { name: /nebula/ })).toHaveCount(0);
+
+    await page.goto(`/wordbooks/${wordbookId}?q=${updatedWord.meaning}`);
+    await expect(page.getByRole('link', { name: /aurora/ })).toBeVisible();
+    await expect(page.getByRole('link', { name: /nebula/ })).toHaveCount(0);
+
+    await page.goto(`/wordbooks/${wordbookId}/words/${firstWordId}`);
+    await page.getByRole('button', { name: '削除' }).click();
+    await expect(
+      page.getByRole('heading', { name: '単語を削除しますか？' }),
+    ).toBeVisible();
+    await page.getByRole('button', { name: '削除する' }).click();
+    await page.waitForURL(`/wordbooks/${wordbookId}`);
+    await expect(page.getByRole('link', { name: /aurora/ })).toHaveCount(0);
+
+    await page.goto(`/wordbooks/${wordbookId}`);
+    await page.getByRole('button', { name: '削除' }).click();
+    await expect(
+      page.getByRole('heading', { name: '単語帳を削除しますか？' }),
+    ).toBeVisible();
+    await page.getByRole('button', { name: '削除する' }).click();
+    await page.waitForURL('/dashboard');
+    await expect(page.getByRole('link', { name: updatedTitle })).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'ゲスト' }).click();
+    await page.getByRole('menuitem', { name: 'ログアウト' }).click();
+    await expect(
+      page.getByRole('heading', { name: 'ログアウトしますか？' }),
+    ).toBeVisible();
+    const signOutRequest = page.waitForResponse(
+      (response) =>
+        response.request().method() === 'POST' &&
+        response.url().includes('/dashboard'),
+    );
+    await page.getByRole('button', { name: 'ログアウト' }).click();
+    await signOutRequest;
+    await page.goto('/dashboard');
+    await page.waitForURL('/auth');
+  });
+});

--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -1,0 +1,9 @@
+import type { Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+
+export async function signInAsGuest(page: Page): Promise<void> {
+  await page.goto('/auth');
+  await page.getByRole('button', { name: 'ゲストとして始める' }).click();
+  await page.waitForURL('/dashboard');
+  await expect(page.getByRole('heading', { name: '単語帳' })).toBeVisible();
+}

--- a/e2e/mock-api.mjs
+++ b/e2e/mock-api.mjs
@@ -1,0 +1,341 @@
+import { createServer } from 'node:http';
+
+const port = 3101;
+
+const sessions = new Map();
+let nextGuestId = 1;
+
+function createStore() {
+  return {
+    nextWordbookId: 1,
+    nextWordId: 1,
+    nextMeaningId: 1,
+    nextExampleId: 1,
+    setting: undefined,
+    wordbooks: [],
+  };
+}
+
+function json(res, status, body) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+function noContent(res) {
+  res.writeHead(204);
+  res.end();
+}
+
+function notFound(res) {
+  json(res, 404, { errors: ['Not found'] });
+}
+
+async function readJson(req) {
+  let body = '';
+  for await (const chunk of req) {
+    body += chunk;
+  }
+  return body === '' ? {} : JSON.parse(body);
+}
+
+function getStore(req) {
+  const header = req.headers.authorization;
+  if (header === undefined || !header.startsWith('Bearer ')) {
+    return undefined;
+  }
+  return sessions.get(header.slice('Bearer '.length));
+}
+
+function paginate(data, url) {
+  const page = Number(url.searchParams.get('page') ?? 1);
+  const perPage = Number(url.searchParams.get('per_page') ?? data.length);
+  const start = (page - 1) * perPage;
+  const paged = data.slice(start, start + perPage);
+  return {
+    data: paged,
+    pagination: {
+      current_page: page,
+      total_pages: Math.max(1, Math.ceil(data.length / perPage)),
+      total_count: data.length,
+      per_page: perPage,
+    },
+  };
+}
+
+function findWordbook(store, id) {
+  return store.wordbooks.find((wordbook) => wordbook.id === id);
+}
+
+function wordListItem(word) {
+  const firstMeaning = word.meanings[0];
+  return {
+    id: word.id,
+    spelling: word.spelling,
+    status: word.status,
+    next_review_at: word.next_review_at,
+    first_meaning:
+      firstMeaning === undefined ? null : { definition: firstMeaning.definition },
+  };
+}
+
+function createMeanings(store, attributes = []) {
+  return attributes.map((meaning, index) => ({
+    id: store.nextMeaningId++,
+    definition: meaning.definition,
+    display_order: meaning.display_order ?? index + 1,
+    examples: (meaning.examples_attributes ?? []).map((example, exampleIndex) => ({
+      id: store.nextExampleId++,
+      sentence: example.sentence,
+      translation: example.translation,
+      display_order: example.display_order ?? exampleIndex + 1,
+    })),
+  }));
+}
+
+function updateMeanings(store, word, attributes = []) {
+  for (const meaningInput of attributes) {
+    if (meaningInput.id === undefined) {
+      word.meanings.push(...createMeanings(store, [meaningInput]));
+      continue;
+    }
+
+    const meaning = word.meanings.find((item) => item.id === meaningInput.id);
+    if (meaning === undefined) continue;
+
+    if (meaningInput.definition !== undefined) {
+      meaning.definition = meaningInput.definition;
+    }
+    if (meaningInput.display_order !== undefined) {
+      meaning.display_order = meaningInput.display_order;
+    }
+
+    for (const exampleInput of meaningInput.examples_attributes ?? []) {
+      if (exampleInput.id === undefined) {
+        meaning.examples.push({
+          id: store.nextExampleId++,
+          sentence: exampleInput.sentence ?? '',
+          translation: exampleInput.translation ?? '',
+          display_order:
+            exampleInput.display_order ?? meaning.examples.length + 1,
+        });
+        continue;
+      }
+
+      const example = meaning.examples.find(
+        (item) => item.id === exampleInput.id,
+      );
+      if (example === undefined) continue;
+      if (exampleInput.sentence !== undefined) {
+        example.sentence = exampleInput.sentence;
+      }
+      if (exampleInput.translation !== undefined) {
+        example.translation = exampleInput.translation;
+      }
+      if (exampleInput.display_order !== undefined) {
+        example.display_order = exampleInput.display_order;
+      }
+    }
+  }
+}
+
+function nextReviewAt(store, status) {
+  const fallback = {
+    hard: { days: 1, hours: 0, minutes: 0 },
+    uncertain: { days: 3, hours: 0, minutes: 0 },
+    easy: { days: 7, hours: 0, minutes: 0 },
+  };
+  const key = `${status}_interval`;
+  const interval = store.setting?.[key] ?? fallback[status];
+  const ms =
+    ((interval.days * 24 + interval.hours) * 60 + interval.minutes) *
+    60 *
+    1000;
+  return new Date(Date.now() + ms).toISOString();
+}
+
+async function handleRequest(req, res) {
+  const url = new URL(req.url ?? '/', `http://127.0.0.1:${port}`);
+
+  if (url.pathname === '/health') {
+    json(res, 200, { ok: true });
+    return;
+  }
+
+  const path = url.pathname.replace(/^\/api\/v1/, '');
+  const segments = path.split('/').filter(Boolean);
+
+  if (req.method === 'POST' && path === '/auth/guest') {
+    const token = `guest-${nextGuestId++}`;
+    sessions.set(token, createStore());
+    json(res, 200, {
+      user: {
+        email: null,
+        name: 'ゲスト',
+        avatar_url: null,
+        guest_expires_at: new Date(
+          Date.now() + 7 * 24 * 60 * 60 * 1000,
+        ).toISOString(),
+      },
+      token,
+    });
+    return;
+  }
+
+  const store = getStore(req);
+  if (store === undefined) {
+    json(res, 401, { errors: ['Unauthorized'] });
+    return;
+  }
+
+  if (path === '/setting') {
+    if (req.method === 'GET') {
+      if (store.setting === undefined) {
+        notFound(res);
+        return;
+      }
+      json(res, 200, store.setting);
+      return;
+    }
+
+    if (req.method === 'POST' || req.method === 'PATCH') {
+      const body = await readJson(req);
+      store.setting = body.setting;
+      json(res, 200, store.setting);
+      return;
+    }
+  }
+
+  if (segments[0] === 'wordbooks' && segments.length === 1) {
+    if (req.method === 'GET') {
+      json(res, 200, paginate(store.wordbooks, url));
+      return;
+    }
+
+    if (req.method === 'POST') {
+      const body = await readJson(req);
+      const wordbook = {
+        id: store.nextWordbookId++,
+        title: body.wordbook.title,
+        created_at: new Date().toISOString(),
+        words: [],
+      };
+      store.wordbooks.push(wordbook);
+      json(res, 201, wordbook);
+      return;
+    }
+  }
+
+  const wordbookId = Number(segments[1]);
+  const wordbook = findWordbook(store, wordbookId);
+  if (segments[0] !== 'wordbooks' || wordbook === undefined) {
+    notFound(res);
+    return;
+  }
+
+  if (segments.length === 2) {
+    if (req.method === 'GET') {
+      json(res, 200, wordbook);
+      return;
+    }
+
+    if (req.method === 'PATCH') {
+      const body = await readJson(req);
+      wordbook.title = body.wordbook.title ?? wordbook.title;
+      json(res, 200, wordbook);
+      return;
+    }
+
+    if (req.method === 'DELETE') {
+      store.wordbooks = store.wordbooks.filter((item) => item.id !== wordbookId);
+      noContent(res);
+      return;
+    }
+  }
+
+  if (segments[2] === 'test' && segments[3] === 'words') {
+    const now = Date.now();
+    json(res, 200, {
+      wordbook: { id: wordbook.id, title: wordbook.title },
+      words: wordbook.words.filter(
+        (word) =>
+          word.next_review_at === null ||
+          Date.parse(word.next_review_at) <= now,
+      ),
+    });
+    return;
+  }
+
+  if (segments[2] === 'words' && segments.length === 3) {
+    if (req.method === 'GET') {
+      json(res, 200, paginate(wordbook.words.map(wordListItem), url));
+      return;
+    }
+
+    if (req.method === 'POST') {
+      const body = await readJson(req);
+      const word = {
+        id: store.nextWordId++,
+        spelling: body.word.spelling,
+        status: body.word.status ?? 'not_studied',
+        next_review_at: body.word.next_review_at ?? null,
+        meanings: createMeanings(store, body.word.meanings_attributes),
+      };
+      wordbook.words.push(word);
+      json(res, 201, word);
+      return;
+    }
+  }
+
+  const wordId = Number(segments[3]);
+  const word = wordbook.words.find((item) => item.id === wordId);
+  if (segments[2] !== 'words' || word === undefined) {
+    notFound(res);
+    return;
+  }
+
+  if (segments.length === 4) {
+    if (req.method === 'GET') {
+      json(res, 200, word);
+      return;
+    }
+
+    if (req.method === 'PATCH') {
+      const body = await readJson(req);
+      if (body.word.spelling !== undefined) {
+        word.spelling = body.word.spelling;
+      }
+      if (body.word.status !== undefined) {
+        word.status = body.word.status;
+        if (body.word.status !== 'not_studied') {
+          word.next_review_at = nextReviewAt(store, body.word.status);
+        }
+      }
+      updateMeanings(store, word, body.word.meanings_attributes);
+      json(res, 200, word);
+      return;
+    }
+
+    if (req.method === 'DELETE') {
+      wordbook.words = wordbook.words.filter((item) => item.id !== wordId);
+      noContent(res);
+      return;
+    }
+  }
+
+  notFound(res);
+}
+
+const server = createServer((req, res) => {
+  handleRequest(req, res).catch((error) => {
+    console.error(error);
+    json(res, 500, { errors: ['Internal server error'] });
+  });
+});
+
+server.listen(port, '127.0.0.1', () => {
+  console.log(`Mock API listening on http://127.0.0.1:${port}`);
+});
+
+process.on('SIGTERM', () => {
+  server.close(() => process.exit(0));
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,10 +18,19 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'] },
     },
   ],
-  webServer: {
-    command: 'pnpm dev',
-    url: 'http://localhost:3000',
-    reuseExistingServer: true,
-    timeout: 120_000,
-  },
+  webServer: [
+    {
+      command: 'node e2e/mock-api.mjs',
+      url: 'http://127.0.0.1:3101/health',
+      reuseExistingServer: true,
+      timeout: 30_000,
+    },
+    {
+      command:
+        'API_URL=http://127.0.0.1:3101/api/v1 AUTH_SECRET=e2e-secret pnpm dev',
+      url: 'http://localhost:3000',
+      reuseExistingServer: true,
+      timeout: 120_000,
+    },
+  ],
 });


### PR DESCRIPTION
## Summary
- Add Playwright coverage for auth redirects, guest login, wordbook and word lifecycles, filters, flashcard evaluation, settings persistence, deletion, and sign out.
- Add a lightweight in-memory mock API for E2E runs so the frontend flows can execute without a separate Rails server.

Closes #92